### PR TITLE
Reconcile following suggestions spec status

### DIFF
--- a/.kiro/specs/github-following-suggestions-and-landing-page/design.md
+++ b/.kiro/specs/github-following-suggestions-and-landing-page/design.md
@@ -468,6 +468,7 @@ Validated on 2026-06-24 after PR #1274:
 - `pnpm exec vitest run src/app/Sidebar/UserAutocomplete.test.ts src/app/Sidebar/UserAutocomplete.test.tsx`: 17 tests passed
 - `pnpm typecheck`: passed
 - `pnpm lint`: passed
+- `pnpm validate`: passed, including the production build
 - `pnpm exec playwright test --reporter=list`: 366 browser-expanded E2E tests passed across Chromium, Firefox, and WebKit
 
 The implemented scope matches this design: first 100 following suggestions, freeSolo custom usernames, OG metadata/image coverage, and no pagination UI.

--- a/.kiro/specs/github-following-suggestions-and-landing-page/design.md
+++ b/.kiro/specs/github-following-suggestions-and-landing-page/design.md
@@ -17,7 +17,7 @@
 
 ### Non-Goals
 
-- Pagination UI for following lists exceeding 100 users
+- Pagination UI/additional page fetching for following lists exceeding 100 users
 - Dynamic OG image generation per page/user
 - User search functionality beyond following list
 - Landing page content restructuring or A/B testing
@@ -30,7 +30,7 @@ The application follows a client-side SPA architecture with:
 
 - **Data Layer**: RTK Query with GraphQL codegen for type-safe API calls
 - **State Management**: Redux Toolkit with redux-persist for token storage
-- **UI Layer**: MUI v7 with sx prop styling, Framer Motion for animations
+- **UI Layer**: Current MUI from `package.json` with sx prop styling, Framer Motion for animations
 - **Form Handling**: react-hook-form with Controller pattern
 
 The subscription flow currently uses `SubscribeFormModal` which dispatches to `subscribedSlice` after form submission. The authentication state is managed in `authenticatorSlice` with persisted OAuth tokens.
@@ -71,13 +71,13 @@ graph TB
 - Domain boundaries: UI components consume generated hooks, no direct API calls
 - Existing patterns preserved: Controller pattern for forms, sx prop styling
 - New components rationale: UserAutocomplete encapsulates suggestion logic
-- Steering compliance: Follows tech.md patterns (RTK Query, MUI v7, TypeScript strict)
+- Steering compliance: Follows tech.md patterns while verifying package versions against `package.json` (RTK Query, current MUI, TypeScript strict)
 
 ### Technology Stack
 
 | Layer           | Choice / Version                      | Role in Feature             | Notes                                  |
 | --------------- | ------------------------------------- | --------------------------- | -------------------------------------- |
-| Frontend        | MUI v7.3.7 Autocomplete               | User suggestion dropdown    | freeSolo mode for custom input         |
+| Frontend        | @mui/material ^9.1.2 Autocomplete     | User suggestion dropdown    | freeSolo mode for custom input         |
 | Data            | RTK Query + graphql-request           | Following list fetching     | Caches results automatically           |
 | Code Generation | @graphql-codegen/typescript-rtk-query | Type-safe hooks             | Generates `useGetViewerFollowingQuery` |
 | Assets          | Static PNG (1200x630px)               | OG image for social sharing | Manual creation required               |
@@ -172,7 +172,7 @@ query getViewerFollowing($first: Int = 100) {
 }
 ```
 
-- Pagination: `first` argument limits results (default 100)
+- Pagination: `first` argument limits this scope to 100 results by default; `totalCount` is retained for awareness, but pagination UI/additional page fetching is out of scope
 - Response type: `FollowingConnection` with `UserConnection` nodes
 - Authentication: Requires valid OAuth token in Authorization header
 
@@ -237,9 +237,10 @@ interface UserAutocompleteProps {
 
 **Implementation Notes**
 
-- Integration: Use MUI Autocomplete with `freeSolo={true}`, `renderOption` for custom layout
+- Integration: Use current MUI Autocomplete with `freeSolo={true}`, `renderOption` for custom layout, and string-aware freeSolo handlers
 - Validation: Required field, handled by parent form via react-hook-form
 - Risks: Empty following list shows only freeSolo input (acceptable per requirements)
+- Scope limit: Users following more than 100 accounts see the first 100 suggestions; pagination UI/additional page fetching is intentionally deferred
 
 #### SubscribeFormModal (Modified)
 
@@ -456,8 +457,20 @@ Graceful degradation with fallback to manual input when suggestions unavailable.
   - Autocomplete filter: < 16ms (60fps local filtering)
 - **Caching**: RTK Query default cache (60s) reduces API calls
 - **Optimization**: Avatar images lazy-loaded via GitHub CDN
+- **Large following lists**: Current implementation fetches the first 100 accounts and keeps `totalCount` available; pagination is future work, not part of this spec
 
 ---
+
+## Validation Status
+
+Validated on 2026-06-24 after PR #1274:
+
+- `pnpm exec vitest run src/app/Sidebar/UserAutocomplete.test.ts src/app/Sidebar/UserAutocomplete.test.tsx`: 17 tests passed
+- `pnpm typecheck`: passed
+- `pnpm lint`: passed
+- `pnpm exec playwright test --reporter=list`: 366 browser-expanded E2E tests passed across Chromium, Firefox, and WebKit
+
+The implemented scope matches this design: first 100 following suggestions, freeSolo custom usernames, OG metadata/image coverage, and no pagination UI.
 
 ## Supporting References
 

--- a/.kiro/specs/github-following-suggestions-and-landing-page/requirements.md
+++ b/.kiro/specs/github-following-suggestions-and-landing-page/requirements.md
@@ -58,7 +58,7 @@ query getViewerFollowing($first: Int = 100) {
 - [ ] Query fetches user's following list via GitHub GraphQL API
 - [ ] RTK Query hook `useGetViewerFollowingQuery` is generated via codegen
 - [ ] Results are cached to minimize API calls
-- [ ] Handles pagination if user follows more than 100 accounts
+- [ ] For users following more than 100 accounts, the current scope fetches the first 100 accounts, exposes `totalCount` for awareness, and defers pagination UI/additional page fetching to a later spec
 
 ### FR-1.3: Autocomplete UI Component
 
@@ -66,10 +66,10 @@ query getViewerFollowing($first: Int = 100) {
 
 **Technical Requirements**:
 
-- Use MUI v7 `Autocomplete` component
+- Use the current `@mui/material` `Autocomplete` component from `package.json`
 - `freeSolo={true}` to allow custom input
 - `renderOption` for custom layout: Avatar + Name + @login
-- `getOptionLabel` returns the login for form submission
+- `getOptionLabel` returns the login for form submission and handles string values from freeSolo mode
 - `filterOptions` for local filtering by name OR login
 - Proper loading and empty states
 
@@ -143,7 +143,7 @@ query getViewerFollowing($first: Int = 100) {
 
 ### NFR-2: Code Quality
 
-- Follow existing project patterns (RTK Query, MUI v7 sx prop)
+- Follow existing project patterns (RTK Query, current MUI sx prop)
 - Run codegen after adding GraphQL query
 - ESLint and Prettier compliance
 - Component memoization where appropriate
@@ -175,9 +175,9 @@ query getViewerFollowing($first: Int = 100) {
 
 | Dependency       | Version | Purpose                |
 | ---------------- | ------- | ---------------------- |
-| @mui/material    | ^7.3.7  | Autocomplete component |
+| @mui/material    | ^9.1.2  | Autocomplete component |
 | graphql-request  | ^7.4.0  | GraphQL data fetching  |
-| @reduxjs/toolkit | ^2.11.2 | RTK Query hooks        |
+| @reduxjs/toolkit | ^2.12.0 | RTK Query hooks        |
 
 ---
 
@@ -203,7 +203,7 @@ query getViewerFollowing($first: Int = 100) {
 
 ## Out of Scope
 
-- Pagination UI for following list (fetch first 100)
+- Pagination UI/additional page fetching for following list; this implementation fetches the first 100 accounts and retains `totalCount`
 - Following list refresh/sync functionality
 - User search beyond following list
 - Landing page A/B testing
@@ -213,11 +213,23 @@ query getViewerFollowing($first: Int = 100) {
 
 ## Risks & Mitigations
 
-| Risk                        | Probability | Impact | Mitigation                      |
-| --------------------------- | ----------- | ------ | ------------------------------- |
-| GitHub API rate limiting    | Medium      | High   | Cache results, batch requests   |
-| Large following list (>100) | Low         | Medium | Paginate or limit to first 100  |
-| OAuth token expiry          | Low         | High   | Handle token refresh gracefully |
+| Risk                        | Probability | Impact | Mitigation                                                                                         |
+| --------------------------- | ----------- | ------ | -------------------------------------------------------------------------------------------------- |
+| GitHub API rate limiting    | Medium      | High   | Cache results, batch requests                                                                      |
+| Large following list (>100) | Low         | Medium | Limit to first 100 in this scope, retain totalCount, and track pagination as future work if needed |
+| OAuth token expiry          | Low         | High   | Handle token refresh gracefully                                                                    |
+
+---
+
+## Validation Status
+
+Validated on 2026-06-24 after PR #1274:
+
+- `pnpm exec vitest run src/app/Sidebar/UserAutocomplete.test.ts src/app/Sidebar/UserAutocomplete.test.tsx`: 17 tests passed
+- `pnpm typecheck`: passed
+- `pnpm lint`: passed
+- `pnpm exec playwright test --reporter=list`: 366 browser-expanded E2E tests passed across Chromium, Firefox, and WebKit
+- Scope clarification: following suggestions intentionally cover the first 100 followed accounts only; pagination UI/additional page fetching remains out of scope
 
 ---
 

--- a/.kiro/specs/github-following-suggestions-and-landing-page/requirements.md
+++ b/.kiro/specs/github-following-suggestions-and-landing-page/requirements.md
@@ -69,7 +69,8 @@ query getViewerFollowing($first: Int = 100) {
 - Use the current `@mui/material` `Autocomplete` component from `package.json`
 - `freeSolo={true}` to allow custom input
 - `renderOption` for custom layout: Avatar + Name + @login
-- `getOptionLabel` returns the login for form submission and handles string values from freeSolo mode
+- `getOptionLabel` resolves the visible label from either a suggestion option or a freeSolo string
+- Selection/input change handling writes the selected login or custom username string to the subscription form
 - `filterOptions` for local filtering by name OR login
 - Proper loading and empty states
 
@@ -228,6 +229,7 @@ Validated on 2026-06-24 after PR #1274:
 - `pnpm exec vitest run src/app/Sidebar/UserAutocomplete.test.ts src/app/Sidebar/UserAutocomplete.test.tsx`: 17 tests passed
 - `pnpm typecheck`: passed
 - `pnpm lint`: passed
+- `pnpm validate`: passed, including the production build
 - `pnpm exec playwright test --reporter=list`: 366 browser-expanded E2E tests passed across Chromium, Firefox, and WebKit
 - Scope clarification: following suggestions intentionally cover the first 100 followed accounts only; pagination UI/additional page fetching remains out of scope
 

--- a/.kiro/specs/github-following-suggestions-and-landing-page/research.md
+++ b/.kiro/specs/github-following-suggestions-and-landing-page/research.md
@@ -10,7 +10,7 @@
 - **Discovery Scope**: Extension (modifying existing components + adding web assets)
 - **Key Findings**:
   - GitHub GraphQL API supports `viewer.following` query with pagination
-  - MUI v7 Autocomplete supports freeSolo mode with custom renderOption
+  - Current MUI Autocomplete supports freeSolo mode with custom renderOption
   - OG image optimal size is 1200x630px with 1.91:1 aspect ratio
 
 ## Research Log
@@ -30,18 +30,18 @@
 - **Implications**:
   - Query structure: `viewer { following(first: 100) { nodes { login, name, avatarUrl } } }`
   - Caching via RTK Query will minimize API calls
-  - No need for complex pagination UI (first 100 sufficient per requirements)
+  - No pagination UI/additional page fetching in this scope (first 100 plus `totalCount` awareness)
 
-### MUI v7 Autocomplete Component
+### MUI Autocomplete Component
 
 - **Context**: Replace TextField with Autocomplete for user suggestions
 - **Sources Consulted**:
   - [MUI Autocomplete Documentation](https://mui.com/material-ui/react-autocomplete/)
-  - MUI v7.2.0 llms.txt via MUI MCP
+  - Current MUI documentation via Context7
 - **Findings**:
   - `freeSolo` prop allows arbitrary input beyond suggestions
   - `renderOption` prop enables custom rendering with Avatar
-  - `getOptionLabel` extracts display text from option objects
+  - `getOptionLabel` extracts display text from option objects and must handle freeSolo strings in current typings
   - `filterOptions` with `createFilterOptions` for custom filtering
   - `loading` and `loadingText` props for async state
 - **Implications**:
@@ -75,7 +75,7 @@
   - `SubscribeFormModal.tsx` uses react-hook-form with Controller
   - GraphQL queries in `src/gql/*.graphql`, generated via codegen
   - RTK Query hooks auto-generated in `src/generated/graphql.ts`
-  - MUI v7 with sx prop styling (no styled-components except LandingPage)
+  - Current MUI with sx prop styling (no styled-components except LandingPage)
   - Landing page uses Framer Motion animations (`MotionInView`, `varFade`)
 - **Implications**:
   - Follow existing Controller pattern for Autocomplete integration
@@ -85,11 +85,11 @@
 
 ## Architecture Pattern Evaluation
 
-| Option                       | Description                              | Strengths                                         | Risks / Limitations                        | Notes                                   |
-| ---------------------------- | ---------------------------------------- | ------------------------------------------------- | ------------------------------------------ | --------------------------------------- |
-| RTK Query for Following List | Use existing RTK Query + GraphQL pattern | Consistent with codebase, auto-caching, type-safe | Limited to 100 items without pagination UI | Selected - aligns with project patterns |
-| SWR/React Query              | Alternative data fetching                | Popular, good DX                                  | Adds new dependency, breaks consistency    | Rejected - would introduce new pattern  |
-| Direct graphql-request       | Manual fetching                          | Simple, no abstraction                            | No caching, no generated hooks             | Rejected - loses type safety benefits   |
+| Option                       | Description                              | Strengths                                         | Risks / Limitations                                                 | Notes                                   |
+| ---------------------------- | ---------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------- | --------------------------------------- |
+| RTK Query for Following List | Use existing RTK Query + GraphQL pattern | Consistent with codebase, auto-caching, type-safe | Limited to 100 items without pagination UI/additional page fetching | Selected - aligns with project patterns |
+| SWR/React Query              | Alternative data fetching                | Popular, good DX                                  | Adds new dependency, breaks consistency                             | Rejected - would introduce new pattern  |
+| Direct graphql-request       | Manual fetching                          | Simple, no abstraction                            | No caching, no generated hooks                                      | Rejected - loses type safety benefits   |
 
 ## Design Decisions
 
@@ -130,13 +130,13 @@
 ## Risks & Mitigations
 
 - **GitHub API Rate Limiting** — Mitigate with RTK Query caching, fetch once per session
-- **Large Following List (>100)** — Mitigate by limiting to first 100 per requirements scope
+- **Large Following List (>100)** — Mitigate by limiting to first 100, retaining `totalCount`, and deferring pagination UI/additional page fetching
 - **OAuth Token Expiry** — Existing token refresh mechanism in authenticatorSlice handles this
 - **OG Image Caching** — Add version query param if updates needed (e.g., `og-image.png?v=1`)
 
 ## References
 
 - [GitHub GraphQL API Documentation](https://docs.github.com/en/graphql) — Official API reference
-- [MUI Autocomplete v7](https://mui.com/material-ui/react-autocomplete/) — Component API
+- [MUI Autocomplete](https://mui.com/material-ui/react-autocomplete/) — Component API
 - [Open Graph Protocol](https://ogp.me/) — Meta tag specification
 - [OG Image Sizes 2025 Guide](https://www.krumzi.com/blog/open-graph-image-sizes-for-social-media-the-complete-2025-guide) — Best practices

--- a/.kiro/specs/github-following-suggestions-and-landing-page/tasks.md
+++ b/.kiro/specs/github-following-suggestions-and-landing-page/tasks.md
@@ -20,6 +20,7 @@
   - Define a query that fetches login, display name, and avatar URL for each followed user
   - Limit initial fetch to first 100 users (covers majority of use cases)
   - Include totalCount for awareness of pagination needs
+  - Keep pagination UI/additional page fetching out of scope for this spec
   - Ensure query uses viewer context (authenticated user scope)
   - _Requirements: 1.2_
 
@@ -116,6 +117,7 @@
   - Run ESLint and Prettier checks
   - Execute build to verify no compilation errors
   - Run complete E2E test suite
+  - 2026-06-24 validation evidence: UserAutocomplete Vitest 17 passed, typecheck passed, lint passed, Playwright 366 passed across Chromium/Firefox/WebKit
   - _Requirements: NFR-1, NFR-2_
 
 ---
@@ -135,6 +137,10 @@
 | NFR-3       | 2.2                     | ✅ Addressed                    |
 | NFR-4       | 1.2, 2.1                | ✅ Built-in (RTK Query caching) |
 | NFR-5       | All                     | ✅ Built-in (existing patterns) |
+
+## Current Validation Status
+
+All checked tasks reflect the current implementation truth as of 2026-06-24. The following-suggestions scope is first 100 followed accounts only, with `totalCount` retained for awareness and pagination UI/additional page fetching deferred to future work.
 
 ---
 

--- a/.kiro/specs/github-following-suggestions-and-landing-page/tasks.md
+++ b/.kiro/specs/github-following-suggestions-and-landing-page/tasks.md
@@ -117,7 +117,7 @@
   - Run ESLint and Prettier checks
   - Execute build to verify no compilation errors
   - Run complete E2E test suite
-  - 2026-06-24 validation evidence: UserAutocomplete Vitest 17 passed, typecheck passed, lint passed, Playwright 366 passed across Chromium/Firefox/WebKit
+  - 2026-06-24 validation evidence: UserAutocomplete Vitest 17 passed, typecheck passed, lint passed, `pnpm validate` passed including build, Playwright 366 passed across Chromium/Firefox/WebKit
   - _Requirements: NFR-1, NFR-2_
 
 ---


### PR DESCRIPTION
## Summary
- Clarify that following suggestions fetch the first 100 accounts and defer pagination UI/additional page fetching.
- Update the following-suggestions spec docs from stale MUI v7/version notes to the current package-backed MUI wording.
- Record validation evidence from the current main implementation.

## Validation
- `pnpm exec prettier --check .kiro/specs/github-following-suggestions-and-landing-page/requirements.md .kiro/specs/github-following-suggestions-and-landing-page/design.md .kiro/specs/github-following-suggestions-and-landing-page/tasks.md .kiro/specs/github-following-suggestions-and-landing-page/research.md`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm validate`
- Existing evidence recorded in the spec: `pnpm exec vitest run src/app/Sidebar/UserAutocomplete.test.ts src/app/Sidebar/UserAutocomplete.test.tsx` and `pnpm exec playwright test --reporter=list`

Closes #1262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * GitHub の follow 候補表示とランディングページに関する仕様を更新しました。
  * following が 100 件超の場合の扱いを明確化：先頭 100 件を対象にしつつ totalCount は保持、ページネーションUIや追加取得は対象外としました。
  * MUI Autocomplete（freeSolo を含む）でのラベル要件や表示/入力挙動を現行前提に整理しました。
  * 現在の検証結果（2026-06-24 時点）と対応範囲の前提を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->