### PR TITLE
Replace landing template copy with product messaging

### DIFF
--- a/src/LandingPage/HomeAdvertisement.tsx
+++ b/src/LandingPage/HomeAdvertisement.tsx
@@ -2,6 +2,8 @@ import { Button, Box, Container, Typography } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import { m } from 'framer-motion'
 
+import { GITHUB_AUTH_URL } from '../constants/GITHUB_AUTH_URL'
+
 import { MotionInView, varFade } from './animate'
 import Image from './Image'
 
@@ -40,8 +42,8 @@ export function HomeAdvertisement() {
           >
             <Image
               visibleByDefault
-              alt="rocket"
-              src="https://minimal-assets-api.vercel.app/assets/images/home/rocket.png"
+              alt="Geek Infiltration GitHub activity preview"
+              src="/og-image.png"
               disabledEffect
               sx={{ maxWidth: 460 }}
             />
@@ -59,17 +61,15 @@ export function HomeAdvertisement() {
             sx={{ color: 'common.white', mb: 5 }}
           >
             <Typography variant="h2">
-              Get started with
-              <br /> minimal kit today
+              Track GitHub work
+              <br /> in one place
             </Typography>
           </MotionInView>
           <MotionInView variants={varFade().inDown}>
             <Button
               size="large"
               variant="contained"
-              target="_blank"
-              rel="noopener"
-              href="https://material-ui.com/store/items/minimal-dashboard/"
+              href={GITHUB_AUTH_URL}
               sx={{
                 '&:hover': { bgcolor: 'grey.300' },
                 bgcolor: 'common.white',
@@ -79,7 +79,7 @@ export function HomeAdvertisement() {
                 whiteSpace: 'nowrap',
               }}
             >
-              Purchase Now
+              Login with GitHub
             </Button>
           </MotionInView>
         </Box>

--- a/src/LandingPage/HomeCleanInterfaces.tsx
+++ b/src/LandingPage/HomeCleanInterfaces.tsx
@@ -4,8 +4,6 @@ import { alpha, styled } from '@mui/material/styles'
 import { MotionInView, varFade } from './animate'
 import Image from './Image'
 
-const IMG = [...Array(10)].map(() => '/og-image.png')
-
 const RootStyle = styled('div')(({ theme }) => ({
   paddingBottom: theme.spacing(10),
   paddingTop: theme.spacing(15),
@@ -60,26 +58,14 @@ export function HomeCleanInterfaces() {
         </ContentStyle>
 
         <Box sx={{ position: 'relative' }}>
-          {IMG.map((_, index) => (
-            <MotionInView
-              key={index}
-              variants={varFade().inUp}
-              sx={{
-                left: 0,
-                position: 'absolute',
-                top: 0,
-                ...(index === 0 && { zIndex: 8 }),
-                ...(index === 9 && { position: 'relative', zIndex: 9 }),
-              }}
-            >
-              <Image
-                disabledEffect
-                visibleByDefault
-                alt={`Geek Infiltration timeline preview ${index + 1}`}
-                src={IMG[index]}
-              />
-            </MotionInView>
-          ))}
+          <MotionInView variants={varFade().inUp} sx={{ position: 'relative' }}>
+            <Image
+              disabledEffect
+              visibleByDefault
+              alt="Geek Infiltration timeline preview"
+              src="/og-image.png"
+            />
+          </MotionInView>
         </Box>
       </Container>
     </RootStyle>

--- a/src/LandingPage/HomeCleanInterfaces.tsx
+++ b/src/LandingPage/HomeCleanInterfaces.tsx
@@ -4,12 +4,7 @@ import { alpha, styled } from '@mui/material/styles'
 import { MotionInView, varFade } from './animate'
 import Image from './Image'
 
-const IMG = [...Array(10)].map(
-  (_, index) =>
-    `https://minimal-assets-api.vercel.app/assets/images/home/clean-${
-      index + 1
-    }.png`,
-)
+const IMG = [...Array(10)].map(() => '/og-image.png')
 
 const RootStyle = styled('div')(({ theme }) => ({
   paddingBottom: theme.spacing(10),
@@ -43,7 +38,7 @@ export function HomeCleanInterfaces() {
               variant="overline"
               sx={{ color: 'text.disabled', mb: 2 }}
             >
-              clean & clear
+              subscriptions
             </Typography>
           </MotionInView>
 
@@ -59,7 +54,7 @@ export function HomeCleanInterfaces() {
                 }),
               }}
             >
-              Beautiful, modern and clean user interfaces
+              Subscribe to people and repositories you care about
             </Typography>
           </MotionInView>
         </ContentStyle>
@@ -80,10 +75,8 @@ export function HomeCleanInterfaces() {
               <Image
                 disabledEffect
                 visibleByDefault
-                alt={`clean-${index + 1}`}
-                src={`https://minimal-assets-api.vercel.app/assets/images/home/clean-${
-                  index + 1
-                }.png`}
+                alt={`Geek Infiltration timeline preview ${index + 1}`}
+                src={IMG[index]}
               />
             </MotionInView>
           ))}

--- a/src/LandingPage/HomeDarkMode.tsx
+++ b/src/LandingPage/HomeDarkMode.tsx
@@ -28,24 +28,6 @@ export function HomeDarkMode() {
   return (
     <RootStyle>
       <Container sx={{ position: 'relative' }}>
-        <Image
-          visibleByDefault
-          disabledEffect
-          alt="image shape"
-          src="https://minimal-assets-api.vercel.app/assets/images/home/shape.svg"
-          sx={{
-            bottom: 0,
-            display: { md: 'block', xs: 'none' },
-            height: 720,
-            my: 'auto',
-            opacity: 0.48,
-            position: 'absolute',
-            right: 0,
-            top: 0,
-            width: 720,
-          }}
-        />
-
         <Grid
           container
           spacing={5}
@@ -62,19 +44,20 @@ export function HomeDarkMode() {
                   variant="overline"
                   sx={{ color: 'text.disabled', mb: 2 }}
                 >
-                  Easy switch between styles.
+                  Timeline focus
                 </Typography>
               </MotionInView>
 
               <MotionInView variants={varFade().inUp}>
                 <Typography variant="h2" sx={{ color: 'common.white', mb: 3 }}>
-                  Dark mode
+                  Read GitHub without the noise
                 </Typography>
               </MotionInView>
 
               <MotionInView variants={varFade().inUp}>
                 <Typography sx={{ color: 'common.white', mb: 5 }}>
-                  A dark theme that feels easier on the eyes.
+                  Group related PR, issue, and discussion comments into calm
+                  columns so review work stays scannable.
                 </Typography>
               </MotionInView>
             </ContentStyle>
@@ -84,8 +67,8 @@ export function HomeDarkMode() {
             <MotionInView threshold={0.5} variants={varFade().inUp}>
               <Image
                 disabledEffect
-                alt="light mode"
-                src="https://minimal-assets-api.vercel.app/assets/images/home/lightmode.png"
+                alt="GitHub activity timeline preview"
+                src="/og-image.png"
               />
             </MotionInView>
 
@@ -96,8 +79,8 @@ export function HomeDarkMode() {
             >
               <Image
                 disabledEffect
-                alt="dark mode"
-                src="https://minimal-assets-api.vercel.app/assets/images/home/darkmode.png"
+                alt="GitHub activity focused timeline preview"
+                src="/og-image.png"
               />
             </MotionInView>
           </Grid>

--- a/src/LandingPage/HomeHugePackElements.tsx
+++ b/src/LandingPage/HomeHugePackElements.tsx
@@ -1,6 +1,8 @@
 import { Box, Button, Container, Typography, Grid } from '@mui/material'
 import { alpha, useTheme, styled } from '@mui/material/styles'
 
+import { GITHUB_AUTH_URL } from '../constants/GITHUB_AUTH_URL'
+
 import { MotionInView, varFade } from './animate'
 import Image from './Image'
 
@@ -93,14 +95,14 @@ export function HomeHugePackElements() {
                   variant="overline"
                   sx={{ color: 'text.disabled', mb: 2 }}
                 >
-                  Interface Starter Kit
+                  Geek Infiltration
                 </Typography>
               </MotionInView>
 
               <MotionInView variants={varFade().inUp}>
                 <Typography variant="h2" sx={{ mb: 3 }}>
-                  Huge pack <br />
-                  of elements
+                  GitHub Activity <br />
+                  Visualization
                 </Typography>
               </MotionInView>
 
@@ -111,14 +113,19 @@ export function HomeHugePackElements() {
                     mb: 5,
                   }}
                 >
-                  We collected most popular elements. Menu, sliders, buttons,
-                  inputs etc. are all here. Just dive in!
+                  Track pull requests, issues, and discussions from the
+                  developers and repositories you follow in one clean timeline.
                 </Typography>
               </MotionInView>
 
               <MotionInView variants={varFade().inUp}>
-                <Button size="large" color="inherit" variant="outlined">
-                  View All Components
+                <Button
+                  size="large"
+                  color="inherit"
+                  variant="contained"
+                  href={GITHUB_AUTH_URL}
+                >
+                  Login with GitHub
                 </Button>
               </MotionInView>
             </ContentStyle>
@@ -164,10 +171,8 @@ export function HomeHugePackElements() {
                 >
                   <Image
                     disabledEffect
-                    alt={`screen ${index + 1}`}
-                    src={`https://minimal-assets-api.vercel.app/assets/images/home/screen_${
-                      isLight ? 'light' : 'dark'
-                    }_${index + 1}.png`}
+                    alt={`Geek Infiltration activity preview ${index + 1}`}
+                    src="/og-image.png"
                   />
                 </ScreenStyle>
               ))}

--- a/src/LandingPage/HomeLookingFor.tsx
+++ b/src/LandingPage/HomeLookingFor.tsx
@@ -1,6 +1,8 @@
 import { Button, Container, Typography, Grid } from '@mui/material'
 import { styled } from '@mui/material/styles'
 
+import { GITHUB_AUTH_URL } from '../constants/GITHUB_AUTH_URL'
+
 import { MotionInView, varFade } from './animate'
 import Iconify from './Iconify'
 import Image from './Image'
@@ -34,13 +36,13 @@ export function HomeLookingFor() {
                 component="div"
                 sx={{ color: 'text.disabled' }}
               >
-                Looking For a
+                Ready to explore?
               </Typography>
             </MotionInView>
 
             <MotionInView variants={varFade().inDown}>
               <Typography variant="h2" sx={{ mb: 5, mt: 2 }}>
-                Landing Page Template?
+                Start with GitHub login
               </Typography>
             </MotionInView>
 
@@ -49,12 +51,10 @@ export function HomeLookingFor() {
                 color="inherit"
                 size="large"
                 variant="outlined"
-                target="_blank"
-                rel="noopener"
-                href="https://material-ui.com/store/items/zone-landing-page/"
+                href={GITHUB_AUTH_URL}
                 endIcon={<Iconify icon={'ic:round-arrow-right-alt'} />}
               >
-                Visit Zone Landing
+                Login with GitHub
               </Button>
             </MotionInView>
           </Grid>
@@ -68,8 +68,8 @@ export function HomeLookingFor() {
             >
               <Image
                 disabledEffect
-                alt="rocket"
-                src="https://minimal-assets-api.vercel.app/assets/images/home/zone_screen.png"
+                alt="GitHub activity dashboard"
+                src="/og-image.png"
               />
             </MotionInView>
           </Grid>

--- a/src/LandingPage/HomePricingPlans.tsx
+++ b/src/LandingPage/HomePricingPlans.tsx
@@ -166,6 +166,7 @@ function PlanCard({ plan }: PlanCardProps) {
           fullWidth
           variant={highlighted ? 'contained' : 'outlined'}
           href={GITHUB_AUTH_URL}
+          aria-label={`Login with GitHub for ${title}`}
         >
           Login with GitHub
         </Button>

--- a/src/LandingPage/HomePricingPlans.tsx
+++ b/src/LandingPage/HomePricingPlans.tsx
@@ -1,19 +1,18 @@
 import {
   Box,
   Card,
-  Link,
   Stack,
   Button,
-  Divider,
   Container,
   Typography,
   Grid,
 } from '@mui/material'
 import { useTheme, styled } from '@mui/material/styles'
 
+import { GITHUB_AUTH_URL } from '../constants/GITHUB_AUTH_URL'
+
 import { MotionInView, varFade } from './animate'
 import Iconify from './Iconify'
-import Image from './Image'
 
 const RootStyle = styled('div')(({ theme }) => ({
   backgroundColor: theme.palette.background.neutral,
@@ -37,12 +36,12 @@ export function HomePricingPlans() {
               variant="overline"
               sx={{ color: 'text.disabled', mb: 2 }}
             >
-              pricing plans
+              workflow signals
             </Typography>
           </MotionInView>
           <MotionInView variants={varFade().inDown}>
             <Typography variant="h2" sx={{ mb: 3 }}>
-              The right plan for your business
+              Everything you need to follow GitHub work
             </Typography>
           </MotionInView>
           <MotionInView variants={varFade().inDown}>
@@ -51,17 +50,18 @@ export function HomePricingPlans() {
                 color: isLight ? 'text.secondary' : 'text.primary',
               }}
             >
-              Choose the perfect plan for your needs. Always flexible to grow
+              Connect once, choose subscriptions, and review activity from one
+              authenticated dashboard.
             </Typography>
           </MotionInView>
         </Box>
 
         <Grid container spacing={5}>
           {_homePlans.map((plan) => (
-            <Grid key={plan.license} size={{ xs: 12, md: 4 }}>
+            <Grid key={plan.title} size={{ xs: 12, md: 4 }}>
               <MotionInView
                 variants={
-                  plan.license === 'Standard Plus'
+                  plan.title === 'Timeline aggregation'
                     ? varFade().inDown
                     : varFade().inUp
                 }
@@ -75,22 +75,20 @@ export function HomePricingPlans() {
         <MotionInView variants={varFade().in}>
           <Box sx={{ mt: 10, p: 5, textAlign: 'center' }}>
             <MotionInView variants={varFade().inDown}>
-              <Typography variant="h3">Still have questions?</Typography>
+              <Typography variant="h3">Know what changed today</Typography>
             </MotionInView>
 
             <MotionInView variants={varFade().inDown}>
               <Typography sx={{ color: 'text.secondary', mb: 5, mt: 3 }}>
-                Please describe your case to receive the most accurate advice.
+                Login with GitHub, add the developers or repositories you care
+                about, and keep their activity visible without hunting through
+                tabs.
               </Typography>
             </MotionInView>
 
             <MotionInView variants={varFade().inUp}>
-              <Button
-                size="large"
-                variant="contained"
-                href="mailto:support@minimals.cc?subject=[Feedback] from Customer"
-              >
-                Contact us
+              <Button size="large" variant="contained" href={GITHUB_AUTH_URL}>
+                Login with GitHub
               </Button>
             </MotionInView>
           </Box>
@@ -102,25 +100,23 @@ export function HomePricingPlans() {
 
 type PlanCardProps = {
   plan: {
-    commons: string[]
-    icons: string[]
-    license: string
-    options: string[]
+    description: string
+    icon: string
+    points: string[]
+    title: string
   }
 }
 
 function PlanCard({ plan }: PlanCardProps) {
-  const { commons, icons, license, options } = plan
-
-  const standard = license === 'Standard'
-  const plus = license === 'Standard Plus'
+  const { description, icon, points, title } = plan
+  const highlighted = title === 'Timeline aggregation'
 
   return (
     <Card
       sx={{
         boxShadow: 0,
         p: 5,
-        ...(plus && {
+        ...(highlighted && {
           boxShadow: (theme) => theme.customShadows.z24,
         }),
       }}
@@ -132,23 +128,22 @@ function PlanCard({ plan }: PlanCardProps) {
             component="div"
             sx={{ color: 'text.disabled', mb: 2 }}
           >
-            LICENSE
+            FEATURE
           </Typography>
-          <Typography variant="h4">{license}</Typography>
+          <Typography variant="h4">{title}</Typography>
         </div>
 
-        {standard ? (
-          <Image src={icons[2]} sx={{ height: 40, width: 40 }} />
-        ) : (
-          <Stack direction="row" spacing={1}>
-            {icons.map((icon) => (
-              <Image key={icon} src={icon} sx={{ height: 40, width: 40 }} />
-            ))}
-          </Stack>
-        )}
+        <Iconify
+          icon={icon}
+          sx={{ color: 'primary.main', height: 40, width: 40 }}
+        />
+
+        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+          {description}
+        </Typography>
 
         <Stack spacing={2.5}>
-          {commons.map((option) => (
+          {points.map((option) => (
             <Stack
               key={option}
               spacing={1.5}
@@ -164,97 +159,52 @@ function PlanCard({ plan }: PlanCardProps) {
               <Typography variant="body2">{option}</Typography>
             </Stack>
           ))}
-
-          <Divider sx={{ borderStyle: 'dashed' }} />
-
-          {options.map((option, optionIndex) => {
-            const disabledLine =
-              (standard && optionIndex === 1) ||
-              (standard && optionIndex === 2) ||
-              (standard && optionIndex === 3) ||
-              (plus && optionIndex === 3)
-
-            return (
-              <Stack
-                spacing={1.5}
-                direction="row"
-                key={option}
-                sx={{
-                  alignItems: 'center',
-                  ...(disabledLine && { color: 'text.disabled' }),
-                }}
-              >
-                <Iconify
-                  icon={'eva:checkmark-fill'}
-                  sx={{
-                    color: 'primary.main',
-                    height: 20,
-                    width: 20,
-                    ...(disabledLine && { color: 'text.disabled' }),
-                  }}
-                />
-                <Typography variant="body2">{option}</Typography>
-              </Stack>
-            )
-          })}
-        </Stack>
-
-        <Stack
-          direction="row"
-          sx={{
-            justifyContent: 'flex-end',
-          }}
-        >
-          <Link
-            underline="always"
-            target="_blank"
-            rel="noopener"
-            href="https://material-ui.com/store/license/#i-standard-license"
-            sx={{
-              color: 'text.secondary',
-              alignItems: 'center',
-              display: 'flex',
-              typography: 'body2',
-            }}
-          >
-            Learn more{' '}
-            <Iconify
-              icon={'eva:chevron-right-fill'}
-              sx={{ height: 20, width: 20 }}
-            />
-          </Link>
         </Stack>
 
         <Button
           size="large"
           fullWidth
-          variant={plus ? 'contained' : 'outlined'}
-          target="_blank"
-          rel="noopener"
-          href="https://material-ui.com/store/items/minimal-dashboard/"
+          variant={highlighted ? 'contained' : 'outlined'}
+          href={GITHUB_AUTH_URL}
         >
-          Choose Plan
+          Login with GitHub
         </Button>
       </Stack>
     </Card>
   )
 }
 
-const LICENSES = ['Standard', 'Standard Plus', 'Extended']
-
-const _homePlans = [...Array(3)].map((_, index) => ({
-  commons: ['One end products', '12 months updates', '6 months of support'],
-  icons: [
-    'https://minimal-assets-api.vercel.app/assets/images/home/ic_sketch.svg',
-    'https://minimal-assets-api.vercel.app/assets/images/home/ic_figma.svg',
-    'https://minimal-assets-api.vercel.app/assets/images/home/ic_js.svg',
-    'https://minimal-assets-api.vercel.app/assets/images/home/ic_ts.svg',
-  ],
-  license: LICENSES[index],
-  options: [
-    'JavaScript version',
-    'TypeScript version',
-    'Design Resources',
-    'Commercial applications',
-  ],
-}))
+const _homePlans = [
+  {
+    description: 'Collect the GitHub conversations that matter into one view.',
+    icon: 'eva:layers-fill',
+    points: [
+      'Pull requests, issues, and discussions in one timeline',
+      'Side-by-side columns for people or repositories',
+      'Readable cards with author, source, and time',
+    ],
+    title: 'Timeline aggregation',
+  },
+  {
+    description:
+      'Use GitHub OAuth so the app can read the activity you follow.',
+    icon: 'bytesize:github',
+    points: [
+      'One clear GitHub login entry point',
+      'Authenticated requests through the existing GraphQL API',
+      'No GitHub activity shown before login',
+    ],
+    title: 'GitHub login',
+  },
+  {
+    description:
+      'Pick the developers and repositories you want to keep nearby.',
+    icon: 'eva:bell-fill',
+    points: [
+      'Subscribe to developers or repositories',
+      'Choose PR/Issue or Discussion feeds',
+      'Remove timelines when they are no longer useful',
+    ],
+    title: 'Subscriptions',
+  },
+]

--- a/tests/helpers/auth.ts
+++ b/tests/helpers/auth.ts
@@ -154,6 +154,7 @@ export async function clearAuthState(page: Page) {
   await page.goto('/', { waitUntil: 'domcontentloaded' })
   await page
     .getByRole('link', { name: /login with github/i })
+    .first()
     .waitFor({ state: 'visible' })
 }
 

--- a/tests/page-objects/LandingPage.ts
+++ b/tests/page-objects/LandingPage.ts
@@ -28,12 +28,9 @@ export class LandingPagePO {
       .filter({ hasText: /Laststance\.io/ })
     this.homeSection = page.getByRole('main')
 
-    // GitHub OAuth button - actual implementation uses "Login with GitHub" text
+    // GitHub OAuth renders as links so tests can assert the href contract.
     this.githubLoginButton = page
-      .locator(
-        'button:has-text("Login with GitHub"), ' +
-          '[href*="github.com/login/oauth/authorize"]',
-      )
+      .getByRole('link', { name: /Login with GitHub/i })
       .first()
 
     // Navigation links

--- a/tests/page-objects/LandingPage.ts
+++ b/tests/page-objects/LandingPage.ts
@@ -29,10 +29,12 @@ export class LandingPagePO {
     this.homeSection = page.getByRole('main')
 
     // GitHub OAuth button - actual implementation uses "Login with GitHub" text
-    this.githubLoginButton = page.locator(
-      'button:has-text("Login with GitHub"), ' +
-        '[href*="github.com/login/oauth/authorize"]',
-    )
+    this.githubLoginButton = page
+      .locator(
+        'button:has-text("Login with GitHub"), ' +
+          '[href*="github.com/login/oauth/authorize"]',
+      )
+      .first()
 
     // Navigation links
     this.navLinks = page.locator('nav a, header a')

--- a/tests/suites/01-authentication.spec.ts
+++ b/tests/suites/01-authentication.spec.ts
@@ -39,6 +39,93 @@ test.describe('Authentication Flow', () => {
       )
     })
 
+    test('should explain GitHub activity visualization before login', async ({
+      page,
+      unauthenticatedPage,
+      landingPage,
+    }) => {
+      // Arrange
+      await landingPage.goto()
+
+      // Act
+      const main = landingPage.homeSection
+
+      // Assert
+      await expect(
+        main.getByRole('heading', {
+          name: /GitHub Activity Visualization/i,
+        }),
+      ).toBeVisible()
+      await expect(
+        main.getByText(/Track pull requests, issues, and discussions/i),
+      ).toBeVisible()
+      await expect(
+        main.getByRole('heading', {
+          exact: true,
+          name: 'Timeline aggregation',
+        }),
+      ).toBeVisible()
+      await expect(
+        main.getByRole('heading', { exact: true, name: 'GitHub login' }),
+      ).toBeVisible()
+      await expect(
+        main.getByRole('heading', { exact: true, name: 'Subscriptions' }),
+      ).toBeVisible()
+    })
+
+    test('should not show generic landing template marketing copy', async ({
+      page,
+      unauthenticatedPage,
+      landingPage,
+    }) => {
+      // Arrange
+      await landingPage.goto()
+
+      // Act
+      const main = landingPage.homeSection
+
+      // Assert
+      await expect(main.getByText(/Huge pack\s+of elements/i)).toHaveCount(0)
+      await expect(main.getByText(/Landing Page Template\?/i)).toHaveCount(0)
+      await expect(main.getByText(/Purchase Now/i)).toHaveCount(0)
+      await expect(main.getByText(/Choose Plan/i)).toHaveCount(0)
+    })
+
+    test('should keep landing product message visible on responsive viewports', async ({
+      page,
+      unauthenticatedPage,
+      landingPage,
+    }) => {
+      // Arrange
+      const viewports = [
+        { height: 667, name: 'mobile', width: 375 },
+        { height: 900, name: 'tablet', width: 768 },
+        { height: 900, name: 'desktop', width: 1280 },
+      ]
+
+      for (const viewport of viewports) {
+        await page.setViewportSize({
+          height: viewport.height,
+          width: viewport.width,
+        })
+
+        // Act
+        await landingPage.goto()
+
+        // Assert
+        await expect(
+          page.getByRole('heading', {
+            name: /GitHub Activity Visualization/i,
+          }),
+          `${viewport.name} should show the product hero`,
+        ).toBeVisible()
+        await expect(
+          landingPage.githubLoginButton,
+          `${viewport.name} should keep the GitHub login CTA reachable`,
+        ).toBeVisible()
+      }
+    })
+
     test('should have correct GitHub OAuth URL', async ({
       page,
       unauthenticatedPage,

--- a/tests/suites/05-error-handling.spec.ts
+++ b/tests/suites/05-error-handling.spec.ts
@@ -340,9 +340,9 @@ test.describe('Error Handling', () => {
       await page.goto('/').catch(() => {})
       await page.waitForLoadState('domcontentloaded')
 
-      // Should handle missing localStorage
+      // Should handle missing localStorage by leaving at least one login path visible.
       await expect(
-        page.getByRole('link', { name: /login with github/i }),
+        page.getByRole('link', { name: /login with github/i }).first(),
       ).toBeVisible()
     })
 


### PR DESCRIPTION
## Summary
- Replace generic landing template copy with Geek Infiltration product messaging for GitHub activity visualization.
- Highlight timeline aggregation, GitHub login, and subscriptions in the feature cards and CTAs.
- Swap landing visuals away from external template assets toward the local branded OG image.
- Add E2E coverage for product messaging, removed template copy, responsive visibility, and multiple GitHub login CTAs.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec playwright test tests/suites/01-authentication.spec.ts --reporter=list`
- `pnpm validate`
- Design-review screenshots: desktop `/tmp/geek-landing-desktop-final.png`, mobile `/tmp/geek-landing-mobile-fixed.png`

Closes #1263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ランディングページ全体の文言・CTA・画像プレビューを刷新し、GitHubログイン導線を中心に統一しました。主要ボタン/プランCTAはGitHub認証URLへ遷移するよう更新しました。
* **Bug Fixes**
  * 未認証時のログインリンク/ボタン判定で、複数一致しても先頭要素を正しく対象にできるよう改善しました。
* **Tests**
  * 未ログイン時の表示/非表示、各ビューポートでの表示・到達、エラーハンドリング関連のE2E検証を追加・強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->