### PR TITLE
Complete Release Feed Kiro spec

### DIFF
--- a/.kiro/specs/starred-repos-release-feed/design.md
+++ b/.kiro/specs/starred-repos-release-feed/design.md
@@ -243,6 +243,8 @@ createBrowserRouter([
 
 ### GraphQL Query Contract
 
+Initial starred repository page:
+
 ```graphql
 query getViewerStarredRepositoryReleases(
   $starredFirst: Int = 50
@@ -273,6 +275,10 @@ query getViewerStarredRepositoryReleases(
           first: $releaseCandidateFirst
           orderBy: { field: CREATED_AT, direction: DESC }
         ) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
           nodes {
             id
             name
@@ -291,6 +297,43 @@ query getViewerStarredRepositoryReleases(
 }
 ```
 
+Repository-specific release continuation:
+
+```graphql
+query getRepositoryReleaseCandidates(
+  $owner: String!
+  $name: String!
+  $releaseCandidateFirst: Int = 20
+  $releaseAfter: String
+) {
+  repository(owner: $owner, name: $name) {
+    id
+    nameWithOwner
+    releases(
+      first: $releaseCandidateFirst
+      after: $releaseAfter
+      orderBy: { field: CREATED_AT, direction: DESC }
+    ) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        id
+        name
+        tagName
+        description
+        isDraft
+        isPrerelease
+        publishedAt
+        createdAt
+        url
+      }
+    }
+  }
+}
+```
+
 ### Normalization Rules
 
 - Ignore null repository nodes.
@@ -301,8 +344,9 @@ query getViewerStarredRepositoryReleases(
 - Flatten all repository releases into `ReleaseFeedItem[]`.
 - Sort flattened releases newest-first by timestamp.
 - Dedupe by release `id`.
-- Treat `releaseCandidateFirst` as an input candidate window, not as the final number of visible releases per repository.
-- Do not trim each repository to a display count until after flattening and sorting by release timestamp.
+- Treat `releaseCandidateFirst` as the per-request release page size, not as a fixed candidate cap.
+- Continue fetching additional release pages for a repository until the `publishedAt ?? createdAt` ordered candidate set satisfies the feed's required visible count or the repository release connection is exhausted.
+- Do not trim each repository or the combined feed to a display count until after flattening and sorting by release timestamp.
 - Include a normalization test where a later-published release with an older `createdAt` outranks a newer-created but earlier-published release.
 
 ### ReleaseFeedItem Interface
@@ -331,7 +375,8 @@ interface ReleaseFeedItem {
 
 - Initial query: `starredFirst = 50`, `releaseCandidateFirst = 20`.
 - GitHub GraphQL currently orders repository releases by `CREATED_AT` or `NAME`, not by publication time.
-- Fetch a wider created-order candidate window, then sort and select by `publishedAt ?? createdAt` in app code.
+- Fetch release pages as candidates, then sort and select by `publishedAt ?? createdAt` in app code.
+- If the first release page does not produce enough published-order candidates for the visible feed, request the next release page for that repository before final selection.
 - Store fetched pages in component state as an array of page results or flattened items.
 - Trigger the next query when a bottom sentinel enters view and `hasNextPage` is true.
 - Use `starredAfter = pageInfo.endCursor` for subsequent pages.

--- a/.kiro/specs/starred-repos-release-feed/design.md
+++ b/.kiro/specs/starred-repos-release-feed/design.md
@@ -1,0 +1,437 @@
+# Technical Design Document
+
+## Overview
+
+**Purpose**: Add a Release Feed that shows recent GitHub releases from the authenticated user's starred repositories, and introduce URL-based navigation so Geek Infiltration can support more than one authenticated view.
+
+**Users**: Authenticated users who follow active open-source projects through starred repositories and want a chronological view of release activity without visiting each repository.
+
+**Impact**: Replaces the current auth-only render switch with React Router v7 routes, preserves the existing Sidebar plus content shell for authenticated views, adds a generated GraphQL query for starred repository releases, and creates a Release Feed view under `/releases`.
+
+### Goals
+
+- Use React Router v7 for `/`, `/callback`, `/app`, and `/releases`.
+- Keep the existing timelines view available at `/app`.
+- Show releases from starred repositories in newest-first order.
+- Support loading, empty, error, retry, and pagination states.
+- Render release detail previews with repository context, badges, dates, and Markdown.
+- Add E2E coverage for routing, navigation, data loading, and feed states.
+
+### Non-Goals
+
+- Replacing RTK Query or Redux Persist.
+- Server-side rendering or React Router framework mode.
+- Editing GitHub releases from the app.
+- Persisting release feed data in Redux Persist.
+- Implementing search/filtering beyond chronological starred-repository releases.
+
+## Architecture
+
+### Existing Architecture Analysis
+
+The application is currently a React SPA with:
+
+- **Auth gate**: `src/authenticator/index.tsx` checks `authenticator.accessToken` and renders either `src/app` or `src/LandingPage`.
+- **Shell**: `src/app/index.tsx` renders a full-height MUI `Container` with `Sidebar` and `TimelineContainer`.
+- **Data layer**: `src/constants/api.ts` defines RTK Query using `graphql-request` and the persisted OAuth token from Redux.
+- **GraphQL codegen**: `src/gql/*.graphql` files generate hooks into `src/generated/graphql.ts`.
+- **Tests**: Playwright fixtures mock GitHub GraphQL operations and seed Redux Persist auth state.
+
+The Release Feed should preserve these boundaries. Routing should move view selection out of `Authenticator`, while auth state still comes from Redux Persist after `PersistGate` rehydration.
+
+### Architecture Pattern & Boundary Map
+
+```mermaid
+graph TB
+    subgraph Root["Root Providers"]
+        Main["main.tsx"]
+        Router["RouterProvider"]
+        Store["Redux Provider + PersistGate"]
+    end
+
+    subgraph Routes["Route Layer"]
+        Landing["/ LandingRoute"]
+        Callback["/callback OAuthCallbackRoute"]
+        AuthLayout["AuthenticatedLayout"]
+        AppRoute["/app TimelineRoute"]
+        ReleaseRoute["/releases ReleaseFeedRoute"]
+    end
+
+    subgraph Shell["Authenticated Shell"]
+        Sidebar["Sidebar"]
+        Outlet["Outlet"]
+    end
+
+    subgraph Data["Data Layer"]
+        RTK["RTK Query API"]
+        GQL["Generated GraphQL hooks"]
+        GH["GitHub GraphQL API"]
+    end
+
+    Main --> Store
+    Store --> Router
+    Router --> Landing
+    Router --> Callback
+    Router --> AuthLayout
+    AuthLayout --> Shell
+    Shell --> Sidebar
+    Shell --> Outlet
+    Outlet --> AppRoute
+    Outlet --> ReleaseRoute
+    ReleaseRoute --> GQL
+    GQL --> RTK
+    RTK --> GH
+```
+
+**Architecture Integration**:
+
+- Selected pattern: React Router v7 data router in library mode with route objects.
+- Auth boundary: Protected route component reads Redux auth state after persistence and redirects unauthenticated users to `/`.
+- Shell boundary: Sidebar lives in the authenticated layout and does not remount when moving between `/app` and `/releases`.
+- Data boundary: Release data is fetched through generated RTK Query hooks only; UI components do not call `fetch` directly.
+- State boundary: Release feed pagination state remains in route-local component state plus RTK Query cache, not Redux Persist.
+
+### Technology Stack
+
+| Layer           | Choice / Version                        | Role in Feature                                                        | Notes                                      |
+| --------------- | --------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------ |
+| Routing         | `react-router` v7                       | URL routes, `RouterProvider`, `Navigate`, `Outlet`, route lazy loading | New dependency required before route work  |
+| UI              | MUI from `package.json`                 | Layout, cards, buttons, skeletons, badges                              | Match existing theme and `sx` patterns     |
+| Data            | RTK Query + `graphql-request`           | Authenticated GitHub GraphQL requests                                  | Reuse `src/constants/api.ts`               |
+| Code Generation | GraphQL Code Generator                  | Generate typed release query hooks                                     | Run `pnpm codegen` after query addition    |
+| Markdown        | `react-markdown` or approved equivalent | Render release body preview safely                                     | Add only with implementation task approval |
+| Testing         | Playwright                              | E2E routing and release feed state coverage                            | Reuse existing fixtures and GraphQL mocker |
+
+## System Flows
+
+### Authenticated Routing Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Router
+    participant Guard as AuthenticatedLayout
+    participant Store as Redux Auth State
+    participant Shell as Sidebar + Outlet
+
+    User->>Router: Navigate to /releases
+    Router->>Guard: Match protected route
+    Guard->>Store: Read accessToken
+    alt token exists
+        Guard->>Shell: Render shell and outlet
+        Shell-->>User: Release Feed visible
+    else no token
+        Guard-->>Router: Navigate to /
+        Router-->>User: Landing Page visible
+    end
+```
+
+### OAuth Callback Flow
+
+```mermaid
+sequenceDiagram
+    participant GitHub
+    participant Callback as OAuthCallbackRoute
+    participant OAuth as /login/oauth/access_token
+    participant Store as Redux Store
+    participant Router
+
+    GitHub->>Callback: Redirect with ?code=...
+    Callback->>OAuth: Exchange code for access token
+    OAuth-->>Callback: access_token
+    Callback->>Store: dispatch(login(access_token))
+    Callback->>Router: navigate('/app', replace: true)
+```
+
+### Release Feed Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Feed as ReleaseFeedRoute
+    participant Hook as useGetViewerStarredRepositoryReleasesQuery
+    participant RTK as RTK Query Cache
+    participant GH as GitHub GraphQL API
+
+    Feed->>Hook: Request first starred repo page
+    Hook->>RTK: Cache key by first/after/releasesFirst
+    RTK->>GH: viewer.starredRepositories + repository.releases
+    GH-->>RTK: Repositories, releases, pageInfo
+    RTK-->>Feed: Data, loading, error
+    Feed->>Feed: Flatten releases and sort by publish date
+    Feed-->>Feed: Render list, empty, or error state
+    Feed->>Hook: Request next page when bottom sentinel is visible
+```
+
+## Requirements Traceability
+
+| Requirement | Summary                          | Components                                                   | Interfaces                     | Flows                                 |
+| ----------- | -------------------------------- | ------------------------------------------------------------ | ------------------------------ | ------------------------------------- |
+| 1           | React Router v7 Integration      | Router, AuthenticatedLayout, OAuthCallbackRoute              | RouteObject config             | Authenticated Routing, OAuth Callback |
+| 2           | Navigation and Access            | Sidebar, AppShell                                            | Nav items, active route state  | Authenticated Routing                 |
+| 3           | Release Feed Timeline View       | ReleaseFeedRoute, ReleaseFeedList, ReleaseCard               | ReleaseFeedItem                | Release Feed Data                     |
+| 4           | Data Fetching and Pagination     | `getViewerStarredRepositoryReleases.graphql`, generated hook | GraphQL query variables/result | Release Feed Data                     |
+| 5           | Release Entry Details            | ReleaseCard, ReleaseMarkdownPreview                          | Release detail props           | Release Feed Data                     |
+| 6           | Error Handling and Edge Cases    | ReleaseFeedState, Retry action                               | RTK Query status               | Release Feed Data                     |
+| 7           | Visual Design and Responsiveness | ReleaseFeedRoute, ReleaseCard, Sidebar nav                   | MUI theme                      | All UI flows                          |
+
+## Components and Interfaces
+
+| Component                                    | Domain/Layer | Intent                                                | Req Coverage | Key Dependencies                   | Contracts          |
+| -------------------------------------------- | ------------ | ----------------------------------------------------- | ------------ | ---------------------------------- | ------------------ |
+| `src/router/index.tsx`                       | Route        | Define route tree and lazy route modules              | 1            | React Router v7                    | Route config       |
+| `AuthenticatedLayout`                        | Route/UI     | Protect authenticated routes and render shell         | 1, 2         | Redux auth, `Navigate`, `Outlet`   | Auth guard         |
+| `OAuthCallbackRoute`                         | Route/Auth   | Exchange OAuth code and redirect to `/app`            | 1            | axios, Redux dispatch              | Callback route     |
+| `AppShell`                                   | UI           | Persist Sidebar and route outlet                      | 2, 7         | MUI Container, Sidebar             | Shell layout       |
+| `Sidebar`                                    | UI           | Add timeline/release nav buttons and active state     | 2            | React Router hooks, MUI IconButton | Nav items          |
+| `TimelineRoute`                              | UI           | Render existing timeline view inside shell            | 1, 2         | Existing `TimelineContainer`       | Existing timeline  |
+| `ReleaseFeedRoute`                           | UI/Data      | Fetch and render release timeline                     | 3, 4, 6, 7   | Generated RTK Query hook           | Release feed       |
+| `ReleaseFeedList`                            | UI           | Render sorted release entries and pagination sentinel | 3, 4, 7      | MUI Stack/List                     | List props         |
+| `ReleaseCard`                                | UI           | Show repository, title, tag, date, badges, preview    | 3, 5, 7      | MUI Card, date formatting          | Release item props |
+| `ReleaseMarkdownPreview`                     | UI           | Render collapsible Markdown body preview              | 5, 7         | Markdown renderer                  | Markdown props     |
+| `ReleaseFeedState`                           | UI           | Loading, empty, error, retry, pagination states       | 3, 4, 6      | MUI Alert/Skeleton/Button          | State props        |
+| `getViewerStarredRepositoryReleases.graphql` | Data         | Fetch starred repos and releases                      | 4, 5, 6      | GitHub GraphQL API                 | GraphQL query      |
+
+## Route Design
+
+### Route Tree
+
+```typescript
+createBrowserRouter([
+  {
+    path: '/',
+    lazy: () => import('@/routes/LandingRoute'),
+  },
+  {
+    path: '/callback',
+    lazy: () => import('@/routes/OAuthCallbackRoute'),
+  },
+  {
+    lazy: () => import('@/routes/AuthenticatedLayout'),
+    children: [
+      {
+        path: '/app',
+        lazy: () => import('@/routes/TimelineRoute'),
+      },
+      {
+        path: '/releases',
+        lazy: () => import('@/routes/ReleaseFeedRoute'),
+      },
+    ],
+  },
+])
+```
+
+### Route Behavior
+
+- `/` renders the Landing Page for unauthenticated users.
+- `/` may redirect authenticated users to `/app` to avoid showing a login CTA after rehydration.
+- `/callback` owns OAuth token exchange and redirects to `/app` after `login`.
+- `/app` renders the existing timeline subscriptions view.
+- `/releases` renders the new Release Feed view.
+- Unknown paths should fall back to `/` for unauthenticated users and `/app` for authenticated users unless a dedicated 404 is introduced.
+
+### Auth Guard Contract
+
+`AuthenticatedLayout` must:
+
+- Read `state.authenticator.accessToken` via existing hooks.
+- Render `<Navigate to="/" replace />` when no token exists.
+- Render `<AppShell><Outlet /></AppShell>` when a token exists.
+- Avoid direct `localStorage` parsing; Redux Persist is the source of truth after `PersistGate`.
+
+## Data Layer
+
+### GraphQL Query Contract
+
+```graphql
+query getViewerStarredRepositoryReleases(
+  $starredFirst: Int = 50
+  $starredAfter: String
+  $releasesFirst: Int = 5
+) {
+  viewer {
+    starredRepositories(
+      first: $starredFirst
+      after: $starredAfter
+      orderBy: { field: STARRED_AT, direction: DESC }
+    ) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        id
+        name
+        nameWithOwner
+        url
+        owner {
+          login
+          avatarUrl
+        }
+        releases(
+          first: $releasesFirst
+          orderBy: { field: CREATED_AT, direction: DESC }
+        ) {
+          nodes {
+            id
+            name
+            tagName
+            description
+            isDraft
+            isPrerelease
+            publishedAt
+            createdAt
+            url
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Normalization Rules
+
+- Ignore null repository nodes.
+- Ignore null release nodes.
+- Ignore draft releases where `isDraft === true`.
+- Use `publishedAt ?? createdAt` as the release timestamp.
+- Use `name || tagName` as the visible release title.
+- Flatten all repository releases into `ReleaseFeedItem[]`.
+- Sort flattened releases newest-first by timestamp.
+- Dedupe by release `id`.
+
+### ReleaseFeedItem Interface
+
+```typescript
+interface ReleaseFeedItem {
+  id: string
+  repository: {
+    avatarUrl: string
+    nameWithOwner: string
+    ownerLogin: string
+    url: string
+  }
+  release: {
+    body: string | null
+    isPrerelease: boolean
+    publishedAt: string
+    tagName: string
+    title: string
+    url: string
+  }
+}
+```
+
+### Pagination Strategy
+
+- Initial query: `starredFirst = 50`, `releasesFirst = 5`.
+- Store fetched pages in component state as an array of page results or flattened items.
+- Trigger the next query when a bottom sentinel enters view and `hasNextPage` is true.
+- Use `starredAfter = pageInfo.endCursor` for subsequent pages.
+- Display a bottom loading indicator during pagination.
+- If a next page fails, keep already loaded releases visible and show retry affordance for the failed page.
+
+## UI Design
+
+### Authenticated Shell
+
+- `AppShell` uses the current full-height `Container` layout.
+- Sidebar width and timeline sizing behavior remain unchanged.
+- Content area renders the route outlet and controls its own scrolling.
+- Sidebar route buttons use icon buttons with visible active state and `aria-label`.
+
+### Release Feed Layout
+
+- Desktop: compact Sidebar on the left, feed content in a constrained scrollable column.
+- Tablet/mobile: preserve existing Sidebar behavior and keep cards full-width.
+- Feed heading: "Release Feed".
+- Subheading: "Recent releases from your starred GitHub repositories."
+- List entries are cards with repository avatar, `owner/name`, tag, release title, relative date, and preview.
+
+### Card States
+
+- **Normal release**: title, tag, repository, timestamp, body preview when present.
+- **Pre-release**: show "Pre-release" badge near the tag.
+- **No body**: omit preview and keep spacing compact.
+- **Expanded body**: show Markdown content and collapse affordance.
+- **External navigation**: clicking the title/card link opens `release.url` in a new tab with safe `rel` attributes.
+
+### Loading, Empty, Error, Retry
+
+- Initial loading: skeleton list in the feed content area.
+- Empty starred repositories: message guides user to star repositories on GitHub.
+- Starred repositories with no releases: message says no releases were found.
+- Network/GraphQL error: `Alert` with retry button.
+- Rate limit: display GitHub rate limit wording and retry guidance if available from the error payload.
+- Pagination loading: small bottom spinner or skeleton.
+
+## Accessibility
+
+- Route navigation controls have labels: "Timelines" and "Release Feed".
+- Active route is exposed through `aria-current="page"` or equivalent active state.
+- Release cards use semantic headings in descending order.
+- External links include accessible names that mention the repository and release.
+- Expand/collapse buttons announce expanded state.
+- Loading states use `aria-busy` on the feed region where appropriate.
+- Reduced motion users should not receive nonessential animations.
+
+## Testing Strategy
+
+### Unit/Component
+
+- Release normalization filters null/draft records and sorts newest-first.
+- Release card renders title fallback, tag, prerelease badge, repository identity, and body preview.
+- Release state component renders loading, empty, error, retry, and pagination states.
+
+### E2E
+
+- Unauthenticated `/releases` redirects to `/`.
+- Authenticated `/app` renders existing timeline view.
+- Authenticated `/releases` renders Release Feed shell.
+- Sidebar navigation changes URL and active state between `/app` and `/releases`.
+- GraphQL mock returns starred repositories and releases; feed renders newest-first.
+- Empty starred repositories state is visible.
+- No releases state is visible.
+- Network error state and retry behavior work.
+- Pagination requests the next starred repository page at the bottom sentinel.
+- Release card external link points to the GitHub release URL.
+
+### Validation Commands
+
+- `pnpm codegen`
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm validate`
+- `pnpm exec playwright test tests/suites/01-authentication.spec.ts tests/suites/02-sidebar.spec.ts tests/suites/03-timeline.spec.ts tests/suites/09-release-feed.spec.ts --reporter=list`
+
+## Dependencies and Sequencing
+
+1. Add React Router v7 and route shell first.
+2. Move OAuth callback behavior into `/callback`.
+3. Add Sidebar route navigation after route shell exists.
+4. Add GraphQL query and generated hook before Release Feed UI.
+5. Build Release Feed UI against mocked/generated data.
+6. Add loading, empty, error, retry, and pagination state handling.
+7. Add rich release detail rendering and Markdown preview.
+8. Add E2E coverage after route and data contracts are stable.
+
+## Risks and Mitigations
+
+| Risk                                                        | Impact                             | Mitigation                                                              |
+| ----------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
+| Router migration breaks existing auth flow                  | Users cannot enter app after OAuth | Keep OAuth callback route small, cover with existing authentication E2E |
+| Sidebar remount loses modal state or layout                 | Navigation feels unstable          | Keep Sidebar in `AppShell` outside route outlet                         |
+| GraphQL response is large for users with many starred repos | Slow feed or rate limits           | Limit to 50 repos and 5 releases per repo per page, paginate            |
+| Release body Markdown adds unsafe rendering risk            | XSS or broken UI                   | Use a renderer that escapes HTML by default or sanitize explicitly      |
+| Feed errors hide already loaded releases                    | Poor resilience                    | Keep successful pages visible when pagination fails                     |
+| E2E route tests become brittle                              | CI noise                           | Use GraphQL mocks and role-based locators                               |
+
+## Implementation Notes
+
+- Prefer DAMP E2E tests with explicit expected release titles and dates.
+- Keep route modules lazy to preserve current code-splitting behavior.
+- Keep generated GraphQL code in `src/generated/graphql.ts`; do not hand-edit generated files.
+- Avoid adding Redux slices unless the feed needs cross-route state beyond RTK Query cache.
+- Reuse `formatTime` if it matches release relative-date needs; otherwise add a narrowly scoped formatter.

--- a/.kiro/specs/starred-repos-release-feed/design.md
+++ b/.kiro/specs/starred-repos-release-feed/design.md
@@ -153,7 +153,7 @@ sequenceDiagram
     participant GH as GitHub GraphQL API
 
     Feed->>Hook: Request first starred repo page
-    Hook->>RTK: Cache key by first/after/releasesFirst
+    Hook->>RTK: Cache key by first/after/releaseCandidateFirst
     RTK->>GH: viewer.starredRepositories + repository.releases
     GH-->>RTK: Repositories, releases, pageInfo
     RTK-->>Feed: Data, loading, error
@@ -247,7 +247,7 @@ createBrowserRouter([
 query getViewerStarredRepositoryReleases(
   $starredFirst: Int = 50
   $starredAfter: String
-  $releasesFirst: Int = 5
+  $releaseCandidateFirst: Int = 20
 ) {
   viewer {
     starredRepositories(
@@ -270,7 +270,7 @@ query getViewerStarredRepositoryReleases(
           avatarUrl
         }
         releases(
-          first: $releasesFirst
+          first: $releaseCandidateFirst
           orderBy: { field: CREATED_AT, direction: DESC }
         ) {
           nodes {
@@ -301,6 +301,9 @@ query getViewerStarredRepositoryReleases(
 - Flatten all repository releases into `ReleaseFeedItem[]`.
 - Sort flattened releases newest-first by timestamp.
 - Dedupe by release `id`.
+- Treat `releaseCandidateFirst` as an input candidate window, not as the final number of visible releases per repository.
+- Do not trim each repository to a display count until after flattening and sorting by release timestamp.
+- Include a normalization test where a later-published release with an older `createdAt` outranks a newer-created but earlier-published release.
 
 ### ReleaseFeedItem Interface
 
@@ -326,7 +329,9 @@ interface ReleaseFeedItem {
 
 ### Pagination Strategy
 
-- Initial query: `starredFirst = 50`, `releasesFirst = 5`.
+- Initial query: `starredFirst = 50`, `releaseCandidateFirst = 20`.
+- GitHub GraphQL currently orders repository releases by `CREATED_AT` or `NAME`, not by publication time.
+- Fetch a wider created-order candidate window, then sort and select by `publishedAt ?? createdAt` in app code.
 - Store fetched pages in component state as an array of page results or flattened items.
 - Trigger the next query when a bottom sentinel enters view and `hasNextPage` is true.
 - Use `starredAfter = pageInfo.endCursor` for subsequent pages.
@@ -353,7 +358,7 @@ interface ReleaseFeedItem {
 ### Card States
 
 - **Normal release**: title, tag, repository, timestamp, body preview when present.
-- **Pre-release**: show "Pre-release" badge near the tag.
+- **pre-release**: show "pre-release" badge near the tag.
 - **No body**: omit preview and keep spacing compact.
 - **Expanded body**: show Markdown content and collapse affordance.
 - **External navigation**: clicking the title/card link opens `release.url` in a new tab with safe `rel` attributes.
@@ -382,7 +387,8 @@ interface ReleaseFeedItem {
 ### Unit/Component
 
 - Release normalization filters null/draft records and sorts newest-first.
-- Release card renders title fallback, tag, prerelease badge, repository identity, and body preview.
+- Release normalization preserves a later-published release even when its `createdAt` is older than another candidate.
+- Release card renders title fallback, tag, pre-release badge, repository identity, and body preview.
 - Release state component renders loading, empty, error, retry, and pagination states.
 
 ### E2E

--- a/.kiro/specs/starred-repos-release-feed/spec.json
+++ b/.kiro/specs/starred-repos-release-feed/spec.json
@@ -1,22 +1,22 @@
 {
   "feature_name": "starred-repos-release-feed",
   "created_at": "2026-02-17T00:00:00.000Z",
-  "updated_at": "2026-02-17T01:00:00.000Z",
+  "updated_at": "2026-06-24T17:20:19.000Z",
   "language": "en",
-  "phase": "requirements-generated",
+  "phase": "tasks-generated",
   "approvals": {
     "requirements": {
       "generated": true,
-      "approved": false
+      "approved": true
     },
     "design": {
-      "generated": false,
-      "approved": false
+      "generated": true,
+      "approved": true
     },
     "tasks": {
-      "generated": false,
-      "approved": false
+      "generated": true,
+      "approved": true
     }
   },
-  "ready_for_implementation": false
+  "ready_for_implementation": true
 }

--- a/.kiro/specs/starred-repos-release-feed/tasks.md
+++ b/.kiro/specs/starred-repos-release-feed/tasks.md
@@ -70,10 +70,12 @@
 
 - [ ] 3. Data Layer - Fetch starred repository releases
 
-- [ ] 3.1 Add GraphQL query for starred repository releases
+- [ ] 3.1 Add GraphQL queries for starred repository releases
   - Create `src/gql/getViewerStarredRepositoryReleases.graphql`.
+  - Create `src/gql/getRepositoryReleaseCandidates.graphql` for repository-specific release continuation.
   - Fetch `viewer.starredRepositories` with `pageInfo`, `totalCount`, and repository identity fields.
-  - Fetch a created-order release candidate window per starred repository.
+  - Fetch release candidates per starred repository with release `pageInfo` for follow-up pages.
+  - Continue per-repository release pagination until `publishedAt ?? createdAt` ordered candidates satisfy the required visible feed count or the repository release connection is exhausted.
   - Include release id, title/name, tag, URL, description, pre-release/draft flags, and dates.
   - Include repository owner avatar and `nameWithOwner`.
   - _Requirements: 3, 4, 5_
@@ -83,7 +85,8 @@
 - [ ] 3.2 Generate and verify typed RTK Query hook
   - Run `pnpm codegen`.
   - Verify `useGetViewerStarredRepositoryReleasesQuery` is generated.
-  - Confirm variables for `starredFirst`, `starredAfter`, and `releaseCandidateFirst`.
+  - Verify `useGetRepositoryReleaseCandidatesQuery` is generated for release continuation.
+  - Confirm variables for `starredFirst`, `starredAfter`, `releaseCandidateFirst`, and `releaseAfter`.
   - Confirm existing auth header behavior is reused through `src/constants/api.ts`.
   - _Requirements: 4_
   - _GitHub Issue: #1268_
@@ -93,7 +96,7 @@
   - Filter null nodes and draft releases.
   - Use `publishedAt ?? createdAt` for sorting.
   - Sort newest-first and dedupe by release id.
-  - Add focused tests for sorting, fallback title, draft filtering, null handling, and later-published older-created releases.
+  - Add focused tests for sorting, fallback title, draft filtering, null handling, later-published older-created releases, and release-page continuation.
   - _Requirements: 3, 4, 5, 6_
   - _Contracts: ReleaseFeedItem Interface (design.md)_
   - _GitHub Issue: #1268_

--- a/.kiro/specs/starred-repos-release-feed/tasks.md
+++ b/.kiro/specs/starred-repos-release-feed/tasks.md
@@ -73,8 +73,8 @@
 - [ ] 3.1 Add GraphQL query for starred repository releases
   - Create `src/gql/getViewerStarredRepositoryReleases.graphql`.
   - Fetch `viewer.starredRepositories` with `pageInfo`, `totalCount`, and repository identity fields.
-  - Fetch up to 5 recent releases per starred repository.
-  - Include release id, title/name, tag, URL, description, prerelease/draft flags, and dates.
+  - Fetch a created-order release candidate window per starred repository.
+  - Include release id, title/name, tag, URL, description, pre-release/draft flags, and dates.
   - Include repository owner avatar and `nameWithOwner`.
   - _Requirements: 3, 4, 5_
   - _Contracts: GraphQL Query Contract (design.md)_
@@ -83,7 +83,7 @@
 - [ ] 3.2 Generate and verify typed RTK Query hook
   - Run `pnpm codegen`.
   - Verify `useGetViewerStarredRepositoryReleasesQuery` is generated.
-  - Confirm variables for `starredFirst`, `starredAfter`, and `releasesFirst`.
+  - Confirm variables for `starredFirst`, `starredAfter`, and `releaseCandidateFirst`.
   - Confirm existing auth header behavior is reused through `src/constants/api.ts`.
   - _Requirements: 4_
   - _GitHub Issue: #1268_
@@ -93,7 +93,7 @@
   - Filter null nodes and draft releases.
   - Use `publishedAt ?? createdAt` for sorting.
   - Sort newest-first and dedupe by release id.
-  - Add focused tests for sorting, fallback title, draft filtering, and null handling.
+  - Add focused tests for sorting, fallback title, draft filtering, null handling, and later-published older-created releases.
   - _Requirements: 3, 4, 5, 6_
   - _Contracts: ReleaseFeedItem Interface (design.md)_
   - _GitHub Issue: #1268_
@@ -160,8 +160,8 @@
 
 - [ ] 6. Rich Details - Markdown preview and badges
 
-- [ ] 6.1 Add prerelease and metadata badges
-  - Show "Pre-release" badge for `isPrerelease`.
+- [ ] 6.1 Add pre-release and metadata badges
+  - Map GraphQL `isPrerelease` to a visible "pre-release" badge.
   - Show tag name and relative date in a compact metadata row.
   - Ensure badge color works in light and dark theme.
   - _Requirements: 5, 7_
@@ -199,7 +199,7 @@
 - [ ] 7.2 Add release feed data E2E tests
   - Mock `getViewerStarredRepositoryReleases`.
   - Test multiple repositories with releases render newest-first.
-  - Test release cards show repository name, tag, title, date, and prerelease badge.
+  - Test release cards show repository name, tag, title, date, and pre-release badge.
   - Test release links point to GitHub release URLs.
   - _Requirements: 3, 4, 5_
   - _GitHub Issue: #1272_

--- a/.kiro/specs/starred-repos-release-feed/tasks.md
+++ b/.kiro/specs/starred-repos-release-feed/tasks.md
@@ -1,0 +1,260 @@
+# Implementation Plan
+
+## Task Overview
+
+| Major Task | Description                                            | Requirements | Parallel |
+| ---------- | ------------------------------------------------------ | ------------ | -------- |
+| 1          | Routing - React Router v7 and OAuth callback           | 1            | No       |
+| 2          | Navigation - Sidebar route switching                   | 2, 7         | No       |
+| 3          | Data Layer - Starred repository releases query         | 3, 4, 5, 6   | No       |
+| 4          | Release Feed - Timeline view and cards                 | 3, 5, 7      | No       |
+| 5          | Feed States - Loading, empty, error, retry, pagination | 3, 4, 6, 7   | No       |
+| 6          | Rich Details - Markdown preview and badges             | 5, 7         | Yes      |
+| 7          | Testing & Validation                                   | All          | No       |
+
+---
+
+## Tasks
+
+- [ ] 1. Routing - Introduce React Router v7
+
+- [ ] 1.1 Add React Router v7 dependency and route entry point
+  - Add `react-router` v7 to dependencies.
+  - Create `src/router/index.tsx` with `createBrowserRouter`.
+  - Define route objects for `/`, `/callback`, `/app`, and `/releases`.
+  - Use lazy route modules to preserve existing code-splitting behavior.
+  - Replace `Authenticator` top-level conditional rendering with `RouterProvider`.
+  - _Requirements: 1_
+  - _GitHub Issue: #1266_
+
+- [ ] 1.2 Move OAuth code exchange into `/callback`
+  - Create `OAuthCallbackRoute` that reads the GitHub OAuth `code` query parameter.
+  - Exchange the code through the existing `/login/oauth/access_token` endpoint.
+  - Dispatch `login(access_token)` using the existing authenticator slice.
+  - Redirect to `/app` with history replacement after successful login.
+  - Show existing `FullScreenSpinner` while exchanging the token.
+  - Handle failed token exchange by returning to `/` without exposing sensitive URL state.
+  - _Requirements: 1_
+  - _GitHub Issue: #1266_
+
+- [ ] 1.3 Add authenticated layout route
+  - Create `AuthenticatedLayout` that reads `authenticator.accessToken`.
+  - Redirect unauthenticated `/app` and `/releases` visits to `/`.
+  - Render persistent `AppShell` and `Outlet` when authenticated.
+  - Keep the existing timeline view available at `/app`.
+  - Add fallback handling for unknown routes.
+  - _Requirements: 1, 2_
+  - _GitHub Issue: #1266_
+
+---
+
+- [ ] 2. Navigation - Sidebar route switching
+
+- [ ] 2.1 Add Sidebar navigation controls
+  - Add route controls for timelines (`/app`) and Release Feed (`/releases`).
+  - Use icon buttons with accessible labels and tooltips where useful.
+  - Navigate with React Router APIs instead of manual `window.location` changes.
+  - Preserve the existing subscribe modal button and account menu behavior.
+  - _Requirements: 2, 7_
+  - _GitHub Issue: #1267_
+
+- [ ] 2.2 Add active route state
+  - Use route state to highlight the active Sidebar control.
+  - Expose active state with `aria-current="page"` or equivalent accessible state.
+  - Verify Sidebar stays mounted while moving between `/app` and `/releases`.
+  - Confirm browser back/forward navigation updates the active state.
+  - _Requirements: 2, 7_
+  - _GitHub Issue: #1267_
+
+---
+
+- [ ] 3. Data Layer - Fetch starred repository releases
+
+- [ ] 3.1 Add GraphQL query for starred repository releases
+  - Create `src/gql/getViewerStarredRepositoryReleases.graphql`.
+  - Fetch `viewer.starredRepositories` with `pageInfo`, `totalCount`, and repository identity fields.
+  - Fetch up to 5 recent releases per starred repository.
+  - Include release id, title/name, tag, URL, description, prerelease/draft flags, and dates.
+  - Include repository owner avatar and `nameWithOwner`.
+  - _Requirements: 3, 4, 5_
+  - _Contracts: GraphQL Query Contract (design.md)_
+  - _GitHub Issue: #1268_
+
+- [ ] 3.2 Generate and verify typed RTK Query hook
+  - Run `pnpm codegen`.
+  - Verify `useGetViewerStarredRepositoryReleasesQuery` is generated.
+  - Confirm variables for `starredFirst`, `starredAfter`, and `releasesFirst`.
+  - Confirm existing auth header behavior is reused through `src/constants/api.ts`.
+  - _Requirements: 4_
+  - _GitHub Issue: #1268_
+
+- [ ] 3.3 Add release normalization helper
+  - Flatten repository release nodes into `ReleaseFeedItem[]`.
+  - Filter null nodes and draft releases.
+  - Use `publishedAt ?? createdAt` for sorting.
+  - Sort newest-first and dedupe by release id.
+  - Add focused tests for sorting, fallback title, draft filtering, and null handling.
+  - _Requirements: 3, 4, 5, 6_
+  - _Contracts: ReleaseFeedItem Interface (design.md)_
+  - _GitHub Issue: #1268_
+
+---
+
+- [ ] 4. Release Feed - Timeline view and cards
+
+- [ ] 4.1 Create Release Feed route page
+  - Create a route module for `/releases`.
+  - Render heading "Release Feed" and supporting copy.
+  - Fetch the first starred repository page through the generated hook.
+  - Pass normalized release items into the feed list.
+  - Keep content scrollable inside the existing authenticated shell.
+  - _Requirements: 3, 4, 7_
+  - _GitHub Issue: #1269_
+
+- [ ] 4.2 Build release list and release card components
+  - Render releases as a newest-first vertical timeline or list.
+  - Show repository avatar, owner/name, release title, tag, and relative publish date.
+  - Use release title fallback `name || tagName`.
+  - Link each release to its GitHub release URL in a new tab.
+  - Keep card layout responsive across mobile, tablet, and desktop.
+  - _Requirements: 3, 5, 7_
+  - _GitHub Issue: #1269_
+
+- [ ] 4.3 Preserve existing timeline route
+  - Extract the existing `TimelineContainer` route content if needed.
+  - Ensure `/app` continues to render existing subscribed timelines.
+  - Verify existing timeline E2E coverage still passes after routing changes.
+  - _Requirements: 1, 2_
+  - _GitHub Issue: #1269_
+
+---
+
+- [ ] 5. Feed States - Loading, empty, error, retry, pagination
+
+- [ ] 5.1 Add initial loading and empty states
+  - Show skeleton or spinner while first release page loads.
+  - Show a "no starred repositories" state when `totalCount` is zero.
+  - Show a "no releases found" state when starred repos exist but no releases remain after filtering.
+  - Keep messages concise and action-oriented.
+  - _Requirements: 3, 6, 7_
+  - _GitHub Issue: #1270_
+
+- [ ] 5.2 Add error and retry states
+  - Show a user-friendly error state for network or GraphQL failures.
+  - Add retry button that re-fetches the failed query.
+  - Detect rate limit wording when available and show retry guidance.
+  - Keep already loaded pages visible if pagination fails.
+  - _Requirements: 4, 6, 7_
+  - _GitHub Issue: #1270_
+
+- [ ] 5.3 Add infinite scroll pagination
+  - Track `pageInfo.endCursor` and `hasNextPage`.
+  - Request additional starred repository pages when a bottom sentinel becomes visible.
+  - Show bottom loading indicator while pagination is in progress.
+  - Dedupe releases across pages.
+  - Stop requesting pages when `hasNextPage` is false.
+  - _Requirements: 4, 6, 7_
+  - _GitHub Issue: #1270_
+
+---
+
+- [ ] 6. Rich Details - Markdown preview and badges
+
+- [ ] 6.1 Add prerelease and metadata badges
+  - Show "Pre-release" badge for `isPrerelease`.
+  - Show tag name and relative date in a compact metadata row.
+  - Ensure badge color works in light and dark theme.
+  - _Requirements: 5, 7_
+  - _GitHub Issue: #1271_
+
+- [ ] 6.2 Add Markdown body preview
+  - Render release description as Markdown with safe defaults.
+  - Collapse preview to the first 3 lines by default.
+  - Add expand/collapse button with accessible expanded state.
+  - Omit preview UI when no description exists.
+  - Add dependency only if an approved Markdown renderer is needed.
+  - _Requirements: 5, 7_
+  - _GitHub Issue: #1271_
+
+- [ ] 6.3 Add accessible external release links
+  - Give each external link an accessible name including repository and release title.
+  - Use `target="_blank"` and safe `rel` attributes.
+  - Confirm keyboard users can reach and activate release links.
+  - _Requirements: 3, 5, 7_
+  - _GitHub Issue: #1271_
+
+---
+
+- [ ] 7. Testing and Final Validation
+
+- [ ] 7.1 Add routing and navigation E2E tests
+  - Test unauthenticated `/releases` redirects to `/`.
+  - Test authenticated `/app` renders the existing timeline view.
+  - Test authenticated `/releases` renders the Release Feed view.
+  - Test Sidebar navigation changes URL and active route state.
+  - Test browser back/forward across `/app` and `/releases`.
+  - _Requirements: 1, 2, 7_
+  - _GitHub Issue: #1272_
+
+- [ ] 7.2 Add release feed data E2E tests
+  - Mock `getViewerStarredRepositoryReleases`.
+  - Test multiple repositories with releases render newest-first.
+  - Test release cards show repository name, tag, title, date, and prerelease badge.
+  - Test release links point to GitHub release URLs.
+  - _Requirements: 3, 4, 5_
+  - _GitHub Issue: #1272_
+
+- [ ] 7.3 Add feed state E2E tests
+  - Test initial loading state.
+  - Test no starred repositories state.
+  - Test starred repositories with no releases state.
+  - Test network error and retry behavior.
+  - Test pagination loads next page when the bottom sentinel is reached.
+  - _Requirements: 3, 4, 6, 7_
+  - _GitHub Issue: #1272_
+
+- [ ] 7.4 Run full validation suite
+  - Run `pnpm codegen` after GraphQL query changes.
+  - Run `pnpm typecheck`.
+  - Run `pnpm lint`.
+  - Run `pnpm validate`.
+  - Run full Playwright E2E in CI.
+  - Confirm CodeRabbit has no unresolved review threads before merge.
+  - _Requirements: All_
+  - _GitHub Issue: #1272_
+
+---
+
+## Requirements Coverage Matrix
+
+| Requirement | Task(s)                                               | Coverage     |
+| ----------- | ----------------------------------------------------- | ------------ |
+| 1           | 1.1, 1.2, 1.3, 4.3, 7.1                               | Planned full |
+| 2           | 1.3, 2.1, 2.2, 4.3, 7.1                               | Planned full |
+| 3           | 3.1, 3.3, 4.1, 4.2, 5.1, 7.2, 7.3                     | Planned full |
+| 4           | 3.1, 3.2, 3.3, 4.1, 5.2, 5.3, 7.2, 7.3                | Planned full |
+| 5           | 3.1, 3.3, 4.2, 6.1, 6.2, 6.3, 7.2                     | Planned full |
+| 6           | 3.3, 5.1, 5.2, 5.3, 7.3                               | Planned full |
+| 7           | 2.1, 2.2, 4.1, 4.2, 5.1, 5.2, 6.1, 6.2, 6.3, 7.1, 7.3 | Planned full |
+
+## Current Validation Status
+
+This spec is implementation-ready as of 2026-06-24. The remaining implementation work is intentionally split across GitHub Issues #1266 through #1272 so routing, navigation, data, UI, states, details, and test coverage can land in reviewable increments.
+
+## Parallel Execution Notes
+
+Tasks marked as parallel-safe are limited because routing and data contracts are prerequisites for most UI work.
+
+- Task 6 can start after Task 4 establishes the release card contract, even while Task 5 state handling continues.
+- Task 7.1 can begin after Task 1 and Task 2.
+- Task 7.2 can begin after Task 3 and Task 4.
+- Task 7.3 can begin after Task 5.
+
+**Recommended execution order:**
+
+1. Task 1 - routing foundation.
+2. Task 2 - Sidebar navigation on top of routes.
+3. Task 3 - release data query and normalization.
+4. Task 4 - base Release Feed view.
+5. Task 5 and Task 6 - state handling and rich details.
+6. Task 7 - E2E coverage and full validation.


### PR DESCRIPTION
## Summary
- Add the Release Feed technical design for routing, data, UI, states, and tests
- Add implementation-sized tasks mapped to GitHub Issues #1266 through #1272
- Mark the starred-repos-release-feed Kiro spec as implementation-ready

Closes #1265

## Validation
- `jq . .kiro/specs/starred-repos-release-feed/spec.json`
- `git diff --check HEAD^ HEAD`
- `pnpm validate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * スター付きリポジトリのリリースを時系列で表示する「Release Feed」を追加し、`/releases` から閲覧できるようになりました。
  * 読み込み・空・エラー・リトライ・ページングなどの状態に対応し、カード表示の展開プレビューや外部リンクの新規タブ表示も整備しました。
* **Documentation**
  * Release Feedの設計指針と実装計画、検証観点などのドキュメントを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->