### PR TITLE
Add Sidebar navigation for timeline and releases views

### DIFF
--- a/src/app/Sidebar/index.tsx
+++ b/src/app/Sidebar/index.tsx
@@ -1,6 +1,9 @@
-import { Stack } from '@mui/material'
+import NewReleasesIcon from '@mui/icons-material/NewReleases'
+import ViewTimelineIcon from '@mui/icons-material/ViewTimeline'
+import { Stack, Tooltip, alpha, styled } from '@mui/material'
 import type { PropsWithChildren } from 'react'
 import React, { memo } from 'react'
+import { NavLink } from 'react-router'
 
 import useModalControl from '../../hooks/useModalControl'
 
@@ -8,20 +11,101 @@ import UserMenuButton from './AccountMenu'
 import SubscribeFormModal from './SubscribeFormModal'
 import SubscribeFormModalButton from './SubscribeFormModalButton'
 
+const SIDEBAR_WIDTH_PX = 70
+const SIDEBAR_BUTTON_SIZE_PX = 46
+
+const NAVIGATION_ITEMS = [
+  {
+    icon: ViewTimelineIcon,
+    label: 'Timeline',
+    testId: 'sidebar-timeline-link',
+    to: '/app',
+  },
+  {
+    icon: NewReleasesIcon,
+    label: 'Release Feed',
+    testId: 'sidebar-release-feed-link',
+    to: '/releases',
+  },
+] as const
+
+const SidebarNavigationLink = styled(NavLink)(({ theme }) => ({
+  alignItems: 'center',
+  borderRadius: theme.shape.borderRadius,
+  color: theme.palette.text.secondary,
+  display: 'inline-flex',
+  height: SIDEBAR_BUTTON_SIZE_PX,
+  justifyContent: 'center',
+  minHeight: SIDEBAR_BUTTON_SIZE_PX,
+  minWidth: SIDEBAR_BUTTON_SIZE_PX,
+  textDecoration: 'none',
+  transition: theme.transitions.create(['background-color', 'color'], {
+    duration: theme.transitions.duration.shortest,
+  }),
+  width: SIDEBAR_BUTTON_SIZE_PX,
+  '&.active': {
+    backgroundColor: alpha(theme.palette.primary.main, 0.18),
+    color: theme.palette.primary.main,
+  },
+  '&:focus-visible': {
+    outline: `2px solid ${theme.palette.primary.main}`,
+    outlineOffset: 2,
+  },
+  '&:hover': {
+    backgroundColor: alpha(theme.palette.primary.main, 0.12),
+    color: theme.palette.primary.main,
+  },
+}))
+
+/**
+ * Renders authenticated view links so Sidebar controls URL state and active view styling.
+ * @returns The compact Timeline and Release Feed navigation controls.
+ * @example
+ * <SidebarNavigation />
+ */
+const SidebarNavigation = memo(() => {
+  return (
+    <Stack
+      aria-label="Authenticated views"
+      component="nav"
+      direction="column"
+      spacing={1}
+    >
+      {NAVIGATION_ITEMS.map((item) => {
+        const Icon = item.icon
+
+        return (
+          <Tooltip key={item.to} title={item.label} placement="right">
+            <SidebarNavigationLink
+              aria-label={item.label}
+              data-testid={item.testId}
+              end
+              to={item.to}
+            >
+              <Icon fontSize="small" />
+            </SidebarNavigationLink>
+          </Tooltip>
+        )
+      })}
+    </Stack>
+  )
+})
+SidebarNavigation.displayName = 'Sidebar.Navigation'
+
 const SideBarContainer: React.FC<PropsWithChildren> = memo(({ children }) => (
   <Stack
-    direction="column-reverse"
+    direction="column"
     aria-label="Main navigation"
     component="aside"
     data-testid="sidebar"
     sx={{
-      gap: 3,
       alignItems: 'center',
       border: 0,
+      justifyContent: 'space-between',
       margin: 0,
-      maxWidth: '70px',
+      maxWidth: SIDEBAR_WIDTH_PX,
       minHeight: '100%',
-      minWidth: '70px',
+      minWidth: SIDEBAR_WIDTH_PX,
       padding: '8px 0',
     }}
   >
@@ -40,8 +124,16 @@ const Sidebar = memo(() => {
         closeModal={closeModal}
       />
       <SideBarContainer>
-        <UserMenuButton />
-        <SubscribeFormModalButton openModal={openModal} />
+        <SidebarNavigation />
+        <Stack
+          aria-label="Account actions"
+          direction="column"
+          spacing={3}
+          sx={{ alignItems: 'center' }}
+        >
+          <SubscribeFormModalButton openModal={openModal} />
+          <UserMenuButton />
+        </Stack>
       </SideBarContainer>
     </>
   )

--- a/tests/page-objects/Sidebar.ts
+++ b/tests/page-objects/Sidebar.ts
@@ -17,6 +17,8 @@ export class SidebarPO {
 
   // Navigation items
   readonly navItems: Locator
+  readonly timelineNavigationLink: Locator
+  readonly releaseFeedNavigationLink: Locator
   readonly navHome: Locator
   readonly navRepositories: Locator
   readonly navIssues: Locator
@@ -50,6 +52,12 @@ export class SidebarPO {
 
     // Navigation items
     this.navItems = this.sidebarContainer.getByRole('link')
+    this.timelineNavigationLink = this.sidebarContainer.getByRole('link', {
+      name: 'Timeline',
+    })
+    this.releaseFeedNavigationLink = this.sidebarContainer.getByRole('link', {
+      name: 'Release Feed',
+    })
     this.navHome = this.sidebarContainer.locator(
       'a:has-text("Home"), button:has-text("Home")',
     )
@@ -142,6 +150,26 @@ export class SidebarPO {
     return Promise.all(
       items.map((item) => item.textContent().then((t) => t || '')),
     )
+  }
+
+  /**
+   * Clicks the timeline route control exposed by the authenticated Sidebar.
+   * @returns Resolves after the Timeline navigation link is activated.
+   * @example
+   * await sidebar.clickTimelineNavigation()
+   */
+  async clickTimelineNavigation() {
+    await this.timelineNavigationLink.click()
+  }
+
+  /**
+   * Clicks the release feed route control exposed by the authenticated Sidebar.
+   * @returns Resolves after the Release Feed navigation link is activated.
+   * @example
+   * await sidebar.clickReleaseFeedNavigation()
+   */
+  async clickReleaseFeedNavigation() {
+    await this.releaseFeedNavigationLink.click()
   }
 
   /**

--- a/tests/suites/02-sidebar.spec.ts
+++ b/tests/suites/02-sidebar.spec.ts
@@ -43,6 +43,142 @@ test.describe('Sidebar Functionality', () => {
     })
   })
 
+  test.describe('Sidebar Route Navigation', () => {
+    test('shows Timeline and Release Feed route controls without hiding account actions', async ({
+      page,
+      appPage,
+    }) => {
+      // Arrange
+      await appPage.goto()
+
+      // Act
+      const timelineLink = appPage.sidebar.timelineNavigationLink
+      const releaseFeedLink = appPage.sidebar.releaseFeedNavigationLink
+
+      // Assert
+      await expect(timelineLink).toBeVisible()
+      await expect(timelineLink).toHaveAttribute('href', '/app')
+      await expect(releaseFeedLink).toBeVisible()
+      await expect(releaseFeedLink).toHaveAttribute('href', '/releases')
+      await expect(
+        page.getByRole('button', { name: 'Add subscription' }),
+      ).toBeVisible()
+      await expect(
+        page.getByRole('button', { name: 'Open account menu' }),
+      ).toBeVisible()
+    })
+
+    test('changes the URL, visible view, and active route state from Sidebar controls', async ({
+      page,
+      appPage,
+    }) => {
+      // Arrange
+      await appPage.goto()
+
+      // Assert
+      await expect(appPage.sidebar.timelineNavigationLink).toHaveAttribute(
+        'aria-current',
+        'page',
+      )
+
+      // Act
+      await appPage.sidebar.clickReleaseFeedNavigation()
+
+      // Assert
+      await expect(page).toHaveURL(/\/releases$/)
+      await expect(appPage.releaseFeedRoute).toBeVisible()
+      await expect(appPage.sidebar.releaseFeedNavigationLink).toHaveAttribute(
+        'aria-current',
+        'page',
+      )
+      await expect(appPage.sidebar.timelineNavigationLink).not.toHaveAttribute(
+        'aria-current',
+        'page',
+      )
+
+      // Act
+      await appPage.sidebar.clickTimelineNavigation()
+
+      // Assert
+      await expect(page).toHaveURL(/\/app$/)
+      await expect(appPage.timelineContainer).toBeVisible()
+      await expect(appPage.sidebar.timelineNavigationLink).toHaveAttribute(
+        'aria-current',
+        'page',
+      )
+      await expect(
+        appPage.sidebar.releaseFeedNavigationLink,
+      ).not.toHaveAttribute('aria-current', 'page')
+    })
+
+    test('keeps the same Sidebar instance mounted while switching authenticated views', async ({
+      page,
+      appPage,
+    }) => {
+      // Arrange
+      await appPage.goto()
+      await appPage.sidebar.sidebarContainer.evaluate((element) => {
+        element.setAttribute('data-e2e-sidebar-instance', 'persisted')
+      })
+
+      // Act
+      await appPage.sidebar.clickReleaseFeedNavigation()
+
+      // Assert
+      await expect(page).toHaveURL(/\/releases$/)
+      await expect(appPage.releaseFeedRoute).toBeVisible()
+      await expect(appPage.sidebar.sidebarContainer).toHaveAttribute(
+        'data-e2e-sidebar-instance',
+        'persisted',
+      )
+
+      // Act
+      await page.goBack({ waitUntil: 'domcontentloaded' })
+
+      // Assert
+      await expect(page).toHaveURL(/\/app$/)
+      await expect(appPage.timelineContainer).toBeVisible()
+      await expect(appPage.sidebar.sidebarContainer).toHaveAttribute(
+        'data-e2e-sidebar-instance',
+        'persisted',
+      )
+      await expect(appPage.sidebar.timelineNavigationLink).toHaveAttribute(
+        'aria-current',
+        'page',
+      )
+    })
+
+    test('updates the active Sidebar route when browser back and forward change views', async ({
+      page,
+      appPage,
+    }) => {
+      // Arrange
+      await appPage.goto()
+      await appPage.sidebar.clickReleaseFeedNavigation()
+      await expect(page).toHaveURL(/\/releases$/)
+
+      // Act
+      await page.goBack({ waitUntil: 'domcontentloaded' })
+
+      // Assert
+      await expect(page).toHaveURL(/\/app$/)
+      await expect(appPage.sidebar.timelineNavigationLink).toHaveAttribute(
+        'aria-current',
+        'page',
+      )
+
+      // Act
+      await page.goForward({ waitUntil: 'domcontentloaded' })
+
+      // Assert
+      await expect(page).toHaveURL(/\/releases$/)
+      await expect(appPage.sidebar.releaseFeedNavigationLink).toHaveAttribute(
+        'aria-current',
+        'page',
+      )
+    })
+  })
+
   test.describe('User Profile Display', () => {
     test('should display user avatar', async ({
       page,


### PR DESCRIPTION
## Summary
- Add compact Sidebar route controls for Timeline (/app) and Release Feed (/releases)
- Use React Router NavLink active state so the current authenticated view is visually indicated and exposed via aria-current
- Keep existing add-subscription and account menu actions available while the Sidebar stays mounted across route transitions

## Tests
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm validate
- kill-port 3005 && ./node_modules/.bin/playwright test tests/suites/02-sidebar.spec.ts --project=chromium
- kill-port 3005 && ./node_modules/.bin/playwright test tests/suites/02-sidebar.spec.ts
- kill-port 3005 && ./node_modules/.bin/playwright test tests/suites/01-authentication.spec.ts -g "URL Routing|maintain auth state across navigation" --project=chromium

## Design review
- Captured authenticated /app and /releases screenshots at 1280x900
- Verified /app marks Timeline active, /releases marks Release Feed active, each nav target is 46px square, Sidebar remains 70px wide

Closes #1267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * サイドバーから「Timeline」と「Release Feed」を切り替えられるようになりました。
  * 認証後のサイドバー内で、ナビゲーションとアカウント操作が見やすく整理されました。

* **改善**
  * アクティブ状態、ホバー、フォーカス時の表示がより分かりやすくなりました。
  * サイドバーのレイアウトと幅の扱いが統一されました。

* **テスト**
  * 画面遷移、戻る/進む操作、選択中状態の切り替えを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->