### PR TITLE
feat: add release feed pagination states

### DIFF
--- a/src/routes/ReleaseFeed/normalizeReleaseFeedItems.test.ts
+++ b/src/routes/ReleaseFeed/normalizeReleaseFeedItems.test.ts
@@ -9,6 +9,7 @@ import {
   RELEASE_FEED_GENERIC_ERROR_MESSAGE,
   RELEASE_FEED_RATE_LIMIT_ERROR_MESSAGE,
   formatReleaseFeedErrorMessage,
+  mergeNormalizedViewerStarredRepositoryReleasePages,
   mergeReleaseFeedItems,
   normalizeRepositoryReleaseCandidates,
   normalizeViewerStarredRepositoryReleases,
@@ -94,16 +95,21 @@ function createRepositoryNode(repository: {
  */
 function createViewerQuery(
   repositories: Array<StarredRepositoryNode | null>,
+  pageInfo: {
+    endCursor: string | null
+    hasNextPage: boolean
+  } = {
+    endCursor: 'starred-cursor-1',
+    hasNextPage: true,
+  },
+  totalCount = repositories.length,
 ): GetViewerStarredRepositoryReleasesQuery {
   return {
     viewer: {
       starredRepositories: {
         nodes: repositories,
-        pageInfo: {
-          endCursor: 'starred-cursor-1',
-          hasNextPage: true,
-        },
-        totalCount: repositories.length,
+        pageInfo,
+        totalCount,
       },
     },
   }
@@ -353,6 +359,68 @@ describe('mergeReleaseFeedItems', () => {
     ])
     expect(result[1].release.body).toBe('Cached body')
     expect(result[1].release.title).toBe('Cached title')
+  })
+})
+
+describe('mergeNormalizedViewerStarredRepositoryReleasePages', () => {
+  it('combines infinite-scroll pages newest first and keeps the latest starred cursor', () => {
+    // Arrange
+    const firstRepository = createRepositoryNode({
+      id: 'repo-react',
+      nameWithOwner: 'facebook/react',
+      releases: [
+        createReleaseNode({
+          id: 'release-react-19',
+          name: 'React 19',
+          publishedAt: '2026-03-01T00:00:00Z',
+          tagName: 'v19.0.0',
+        }),
+      ],
+    })
+    const nextRepository = createRepositoryNode({
+      id: 'repo-vite',
+      nameWithOwner: 'vitejs/vite',
+      releases: [
+        createReleaseNode({
+          id: 'release-vite-8',
+          name: 'Vite 8',
+          publishedAt: '2026-04-01T00:00:00Z',
+          tagName: 'v8.0.0',
+        }),
+      ],
+    })
+    const firstPage = normalizeViewerStarredRepositoryReleases(
+      createViewerQuery(
+        [firstRepository],
+        { endCursor: 'starred-cursor-1', hasNextPage: true },
+        2,
+      ),
+    )
+    const nextPage = normalizeViewerStarredRepositoryReleases(
+      createViewerQuery(
+        [nextRepository],
+        { endCursor: null, hasNextPage: false },
+        2,
+      ),
+    )
+
+    // Act
+    const result = mergeNormalizedViewerStarredRepositoryReleasePages(
+      firstPage,
+      nextPage,
+    )
+
+    // Assert
+    expect(result.items.map((item) => item.id)).toEqual([
+      'release-vite-8',
+      'release-react-19',
+    ])
+    expect(result.starredRepositoriesPageInfo).toEqual({
+      endCursor: null,
+      hasNextPage: false,
+    })
+    expect(result.repositoryReleasePageInfos).toHaveLength(2)
+    expect(result.totalStarredRepositories).toBe(2)
   })
 })
 

--- a/src/routes/ReleaseFeed/normalizeReleaseFeedItems.ts
+++ b/src/routes/ReleaseFeed/normalizeReleaseFeedItems.ts
@@ -124,6 +124,40 @@ export function normalizeRepositoryReleaseCandidates(
 }
 
 /**
+ * Combines the initial page and later infinite-scroll pages into one Release Feed view model.
+ * @param pages - Already-normalized starred repository pages in fetch order.
+ * @returns Merged feed items plus the latest starred-repository pagination cursor.
+ * @example
+ * mergeNormalizedViewerStarredRepositoryReleasePages(firstPage, nextPage).items.length // => 10
+ */
+export function mergeNormalizedViewerStarredRepositoryReleasePages(
+  ...pages: readonly NormalizedViewerStarredRepositoryReleases[]
+): NormalizedViewerStarredRepositoryReleases {
+  const latestPage = pages.at(-1)
+  const repositoryReleasePageInfosById = new Map<
+    string,
+    ReleaseFeedRepositoryPageInfo
+  >()
+
+  for (const page of pages) {
+    for (const pageInfo of page.repositoryReleasePageInfos) {
+      // Later pages replace stale cursors while preserving one entry per repository.
+      repositoryReleasePageInfosById.set(pageInfo.repositoryId, pageInfo)
+    }
+  }
+
+  return {
+    items: mergeReleaseFeedItems(...pages.map((page) => page.items)),
+    repositoryReleasePageInfos: [...repositoryReleasePageInfosById.values()],
+    starredRepositoriesPageInfo: latestPage?.starredRepositoriesPageInfo ?? {
+      endCursor: null,
+      hasNextPage: false,
+    },
+    totalStarredRepositories: pages[0]?.totalStarredRepositories ?? 0,
+  }
+}
+
+/**
  * Merges cached and newly loaded pages when Release Feed pagination appends data from RTK Query.
  * @param itemGroups - One or more already-normalized feed item arrays.
  * @returns A newest-first array with duplicate release IDs removed.

--- a/src/routes/ReleasesRoute.test.tsx
+++ b/src/routes/ReleasesRoute.test.tsx
@@ -315,7 +315,7 @@ describe('ReleasesRoute', () => {
 
     // Act
     renderWithTheme(<Component />)
-    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Retry all releases' }))
 
     // Assert
     expect(screen.getByText('React Partial')).toBeVisible()

--- a/src/routes/ReleasesRoute.test.tsx
+++ b/src/routes/ReleasesRoute.test.tsx
@@ -1,5 +1,5 @@
 import { ThemeProvider, createTheme } from '@mui/material'
-import { render, screen, within } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import type { ReactElement } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -11,11 +11,14 @@ import type {
 import { Component } from './ReleasesRoute'
 
 const mockUseGetViewerStarredRepositoryReleasesQuery = vi.fn()
+const mockUseLazyGetViewerStarredRepositoryReleasesQuery = vi.fn()
 
 vi.mock('@/generated/graphql', () => ({
   useGetViewerStarredRepositoryReleasesQuery: (
     variables: GetViewerStarredRepositoryReleasesQueryVariables,
   ) => mockUseGetViewerStarredRepositoryReleasesQuery(variables),
+  useLazyGetViewerStarredRepositoryReleasesQuery: () =>
+    mockUseLazyGetViewerStarredRepositoryReleasesQuery(),
 }))
 
 const theme = createTheme()
@@ -124,6 +127,9 @@ describe('ReleasesRoute', () => {
     vi.clearAllMocks()
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-04-02T00:00:00Z'))
+    mockUseLazyGetViewerStarredRepositoryReleasesQuery.mockReturnValue([
+      vi.fn(),
+    ])
   })
 
   afterEach(() => {
@@ -258,5 +264,66 @@ describe('ReleasesRoute', () => {
         'Star repositories on GitHub to start building your release feed.',
       ),
     ).toBeVisible()
+  })
+
+  it('shows an initial error with a retry action when the release query fails before data loads', () => {
+    // Arrange
+    const refetch = vi.fn()
+    mockUseGetViewerStarredRepositoryReleasesQuery.mockReturnValue({
+      data: undefined,
+      error: new Error('Network request failed'),
+      isFetching: false,
+      isLoading: false,
+      refetch,
+    })
+
+    // Act
+    renderWithTheme(<Component />)
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    // Assert
+    expect(
+      screen.getByText(
+        'Release Feed could not load releases. Please try again.',
+      ),
+    ).toBeVisible()
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps already loaded releases visible when a later query reports a partial error', () => {
+    // Arrange
+    const refetch = vi.fn()
+    const repository = createRepositoryNode({
+      id: 'repo-react',
+      nameWithOwner: 'facebook/react',
+      releases: [
+        createReleaseNode({
+          id: 'release-react-partial',
+          name: 'React Partial',
+          publishedAt: '2026-04-01T00:00:00Z',
+          tagName: 'v20.0.0',
+        }),
+      ],
+    })
+    mockUseGetViewerStarredRepositoryReleasesQuery.mockReturnValue({
+      data: createViewerQuery([repository]),
+      error: new Error('One repository failed'),
+      isFetching: false,
+      isLoading: false,
+      refetch,
+    })
+
+    // Act
+    renderWithTheme(<Component />)
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    // Assert
+    expect(screen.getByText('React Partial')).toBeVisible()
+    expect(
+      screen.getByText(
+        'Release Feed could not load releases. Please try again.',
+      ),
+    ).toBeVisible()
+    expect(refetch).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/routes/ReleasesRoute.tsx
+++ b/src/routes/ReleasesRoute.tsx
@@ -1,7 +1,18 @@
-import { Alert, Button, Skeleton, Stack, Typography } from '@mui/material'
-import { useMemo } from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Skeleton,
+  Stack,
+  Typography,
+} from '@mui/material'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { useGetViewerStarredRepositoryReleasesQuery } from '@/generated/graphql'
+import {
+  useGetViewerStarredRepositoryReleasesQuery,
+  useLazyGetViewerStarredRepositoryReleasesQuery,
+} from '@/generated/graphql'
 
 import {
   RELEASE_FEED_LOADING_SKELETON_COUNT,
@@ -11,7 +22,9 @@ import {
 } from './ReleaseFeed/constants'
 import {
   formatReleaseFeedErrorMessage,
+  mergeNormalizedViewerStarredRepositoryReleasePages,
   normalizeViewerStarredRepositoryReleases,
+  type ReleaseFeedPageInfo,
 } from './ReleaseFeed/normalizeReleaseFeedItems'
 import { ReleaseFeedList } from './ReleaseFeed/ReleaseFeedList'
 
@@ -44,6 +57,68 @@ const RELEASE_FEED_INITIAL_QUERY_VARIABLES = {
   starredFirst: RELEASE_FEED_STARRED_REPOSITORY_PAGE_SIZE,
 }
 
+type NormalizedReleaseFeedPage = ReturnType<
+  typeof normalizeViewerStarredRepositoryReleases
+>
+
+type PaginatedReleaseFeedPageState = {
+  initialData: unknown
+  page: NormalizedReleaseFeedPage
+}
+
+type ReleaseFeedPaginationErrorState = {
+  error: unknown
+  initialData: unknown
+}
+
+/**
+ * Keeps pagination requests scoped to the next starred-repository cursor.
+ * @param pageInfo - Latest starredRepositories pageInfo from the normalized feed.
+ * @returns Query variables for the next Release Feed page, or null when no cursor exists.
+ * @example
+ * createNextReleaseFeedPageVariables({ hasNextPage: true, endCursor: 'cursor' })?.starredAfter // => "cursor"
+ */
+function createNextReleaseFeedPageVariables(pageInfo: ReleaseFeedPageInfo) {
+  if (!pageInfo.hasNextPage || !pageInfo.endCursor) {
+    return null
+  }
+
+  return {
+    ...RELEASE_FEED_INITIAL_QUERY_VARIABLES,
+    starredAfter: pageInfo.endCursor,
+  }
+}
+
+/**
+ * Renders the retryable error alert used by initial, partial, and pagination failures.
+ * @param error - RTK Query or GraphQL error payload to format for users.
+ * @param onRetry - Callback that retries the failed release feed request.
+ * @returns A MUI error alert with a compact retry action.
+ * @example
+ * <ReleaseFeedErrorAlert error={error} onRetry={refetch} />
+ */
+function ReleaseFeedErrorAlert({
+  error,
+  onRetry,
+}: {
+  error: unknown
+  onRetry: () => void
+}) {
+  return (
+    <Alert
+      action={
+        <Button color="inherit" onClick={onRetry} size="small">
+          Retry
+        </Button>
+      }
+      severity="error"
+      variant="outlined"
+    >
+      {formatReleaseFeedErrorMessage(error)}
+    </Alert>
+  )
+}
+
 /**
  * Renders an empty Release Feed result after GitHub returns starred repository data.
  * @param totalStarredRepositories - Number of starred repositories in the initial query result.
@@ -69,6 +144,46 @@ function ReleaseFeedEmptyState({
 }
 
 /**
+ * Renders bottom-of-feed loading and retry affordances while infinite scroll requests another page.
+ * @param error - Pagination failure, if the most recent next-page request failed.
+ * @param isLoading - True while a next starred-repository page is being requested.
+ * @param onRetry - Callback that retries the failed next-page request.
+ * @returns Bottom pagination status UI, or null when the list is idle.
+ * @example
+ * <ReleaseFeedPaginationStatus isLoading={true} error={null} onRetry={loadMore} />
+ */
+function ReleaseFeedPaginationStatus({
+  error,
+  isLoading,
+  onRetry,
+}: {
+  error: unknown
+  isLoading: boolean
+  onRetry: () => void
+}) {
+  if (isLoading) {
+    return (
+      <Stack
+        aria-label="Loading more releases"
+        direction="row"
+        role="status"
+        spacing={1}
+        sx={{ alignItems: 'center', color: 'text.secondary', py: 1 }}
+      >
+        <CircularProgress color="inherit" size={16} />
+        <Typography variant="caption">Loading more releases...</Typography>
+      </Stack>
+    )
+  }
+
+  if (error) {
+    return <ReleaseFeedErrorAlert error={error} onRetry={onRetry} />
+  }
+
+  return null
+}
+
+/**
  * Fetches and renders the authenticated Release Feed timeline at `/releases`.
  * @returns Release Feed route content with heading, query states, and release cards.
  * @example
@@ -79,19 +194,131 @@ export function Component() {
     useGetViewerStarredRepositoryReleasesQuery(
       RELEASE_FEED_INITIAL_QUERY_VARIABLES,
     )
-  const normalizedFeed = useMemo(
+  const [loadMoreStarredRepositories] =
+    useLazyGetViewerStarredRepositoryReleasesQuery()
+  const [additionalReleaseFeedPageStates, setAdditionalReleaseFeedPageStates] =
+    useState<PaginatedReleaseFeedPageState[]>([])
+  const [paginationErrorState, setPaginationErrorState] =
+    useState<ReleaseFeedPaginationErrorState | null>(null)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const isLoadingMoreRef = useRef(false)
+  const paginationSentinelRef = useRef<HTMLDivElement | null>(null)
+  const normalizedInitialFeed = useMemo(
     () => normalizeViewerStarredRepositoryReleases(data),
     [data],
   )
+  const additionalReleaseFeedPages = useMemo(
+    () =>
+      additionalReleaseFeedPageStates
+        // Ignore old next-page results after the first page retries or refetches.
+        .filter((pageState) => pageState.initialData === data)
+        .map((pageState) => pageState.page),
+    [additionalReleaseFeedPageStates, data],
+  )
+  const paginationError =
+    paginationErrorState !== null && paginationErrorState.initialData === data
+      ? paginationErrorState.error
+      : null
+  const normalizedFeed = useMemo(
+    () =>
+      mergeNormalizedViewerStarredRepositoryReleasePages(
+        ...(data ? [normalizedInitialFeed] : []),
+        ...additionalReleaseFeedPages,
+      ),
+    [additionalReleaseFeedPages, data, normalizedInitialFeed],
+  )
   const shouldShowInitialLoading = isLoading && !data
   const shouldShowInitialError = Boolean(error) && !data
+  const shouldShowPartialError = Boolean(error) && Boolean(data)
+  const nextReleaseFeedPageVariables = createNextReleaseFeedPageVariables(
+    normalizedFeed.starredRepositoriesPageInfo,
+  )
+  const hasMoreReleasePages = nextReleaseFeedPageVariables !== null
+  const canLoadMoreReleasePages =
+    hasMoreReleasePages && !shouldShowInitialError && !paginationError
   const shouldShowEmptyState =
     !shouldShowInitialLoading &&
     !shouldShowInitialError &&
+    !hasMoreReleasePages &&
+    !isLoadingMore &&
+    !paginationError &&
     normalizedFeed.items.length === 0
+  const loadMoreReleasePages = useCallback(async () => {
+    const variables = createNextReleaseFeedPageVariables(
+      normalizedFeed.starredRepositoriesPageInfo,
+    )
+
+    if (!variables || isLoadingMoreRef.current) {
+      return
+    }
+
+    isLoadingMoreRef.current = true
+    setIsLoadingMore(true)
+    setPaginationErrorState(null)
+
+    try {
+      const nextPage = await loadMoreStarredRepositories(variables).unwrap()
+      const normalizedNextPage =
+        normalizeViewerStarredRepositoryReleases(nextPage)
+
+      setAdditionalReleaseFeedPageStates((currentPages) => [
+        ...currentPages,
+        {
+          initialData: data,
+          page: normalizedNextPage,
+        },
+      ])
+    } catch (nextPageError) {
+      setPaginationErrorState({
+        error: nextPageError,
+        initialData: data,
+      })
+    } finally {
+      isLoadingMoreRef.current = false
+      setIsLoadingMore(false)
+    }
+  }, [
+    data,
+    loadMoreStarredRepositories,
+    normalizedFeed.starredRepositoriesPageInfo,
+  ])
+
+  useEffect(() => {
+    if (
+      !canLoadMoreReleasePages ||
+      typeof IntersectionObserver === 'undefined'
+    ) {
+      return undefined
+    }
+
+    const paginationSentinel = paginationSentinelRef.current
+
+    if (!paginationSentinel) {
+      return undefined
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          void loadMoreReleasePages()
+        }
+      },
+      {
+        root: null,
+        rootMargin: '320px 0px',
+      },
+    )
+
+    observer.observe(paginationSentinel)
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [canLoadMoreReleasePages, loadMoreReleasePages])
 
   return (
     <Stack
+      aria-busy={shouldShowInitialLoading || isLoadingMore ? true : undefined}
       component="section"
       data-testid="release-feed-route"
       sx={{
@@ -115,28 +342,43 @@ export function Component() {
         {shouldShowInitialLoading ? <ReleaseFeedLoading /> : null}
 
         {shouldShowInitialError ? (
-          <Alert
-            action={
-              <Button
-                color="inherit"
-                onClick={() => {
-                  void refetch()
-                }}
-                size="small"
-              >
-                Retry
-              </Button>
-            }
-            severity="error"
-            variant="outlined"
-          >
-            {formatReleaseFeedErrorMessage(error)}
-          </Alert>
+          <ReleaseFeedErrorAlert
+            error={error}
+            onRetry={() => {
+              void refetch()
+            }}
+          />
+        ) : null}
+
+        {shouldShowPartialError ? (
+          <ReleaseFeedErrorAlert
+            error={error}
+            onRetry={() => {
+              void refetch()
+            }}
+          />
         ) : null}
 
         {normalizedFeed.items.length > 0 ? (
           <ReleaseFeedList items={normalizedFeed.items} />
         ) : null}
+
+        {canLoadMoreReleasePages ? (
+          <Box
+            aria-hidden="true"
+            data-testid="release-feed-pagination-sentinel"
+            ref={paginationSentinelRef}
+            sx={{ height: 1 }}
+          />
+        ) : null}
+
+        <ReleaseFeedPaginationStatus
+          error={paginationError}
+          isLoading={isLoadingMore}
+          onRetry={() => {
+            void loadMoreReleasePages()
+          }}
+        />
 
         {shouldShowEmptyState ? (
           <ReleaseFeedEmptyState

--- a/src/routes/ReleasesRoute.tsx
+++ b/src/routes/ReleasesRoute.tsx
@@ -91,16 +91,19 @@ function createNextReleaseFeedPageVariables(pageInfo: ReleaseFeedPageInfo) {
 
 /**
  * Renders the retryable error alert used by initial, partial, and pagination failures.
+ * @param actionLabel - Visible and accessible label for the retry button.
  * @param error - RTK Query or GraphQL error payload to format for users.
  * @param onRetry - Callback that retries the failed release feed request.
  * @returns A MUI error alert with a compact retry action.
  * @example
- * <ReleaseFeedErrorAlert error={error} onRetry={refetch} />
+ * <ReleaseFeedErrorAlert actionLabel="Retry" error={error} onRetry={refetch} />
  */
 function ReleaseFeedErrorAlert({
+  actionLabel,
   error,
   onRetry,
 }: {
+  actionLabel: string
   error: unknown
   onRetry: () => void
 }) {
@@ -108,7 +111,7 @@ function ReleaseFeedErrorAlert({
     <Alert
       action={
         <Button color="inherit" onClick={onRetry} size="small">
-          Retry
+          {actionLabel}
         </Button>
       }
       severity="error"
@@ -177,7 +180,13 @@ function ReleaseFeedPaginationStatus({
   }
 
   if (error) {
-    return <ReleaseFeedErrorAlert error={error} onRetry={onRetry} />
+    return (
+      <ReleaseFeedErrorAlert
+        actionLabel="Retry next page"
+        error={error}
+        onRetry={onRetry}
+      />
+    )
   }
 
   return null
@@ -343,6 +352,7 @@ export function Component() {
 
         {shouldShowInitialError ? (
           <ReleaseFeedErrorAlert
+            actionLabel="Retry"
             error={error}
             onRetry={() => {
               void refetch()
@@ -352,6 +362,7 @@ export function Component() {
 
         {shouldShowPartialError ? (
           <ReleaseFeedErrorAlert
+            actionLabel="Retry all releases"
             error={error}
             onRetry={() => {
               void refetch()

--- a/tests/suites/09-release-feed.spec.ts
+++ b/tests/suites/09-release-feed.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '../fixtures/auth'
 
+const GITHUB_GRAPHQL_API_URL = 'https://api.github.com/graphql'
+
 type ReleaseNode = {
   createdAt: string
   description: string | null
@@ -20,6 +22,11 @@ type RepositoryNode = {
 }
 
 type ReleaseFeedResponse = Record<string, unknown>
+type ReleaseFeedResponseOptions = {
+  endCursor?: string | null
+  hasNextPage?: boolean
+  totalCount?: number
+}
 
 /**
  * Creates a pending promise so a Playwright test can observe the route loading state before GraphQL resolves.
@@ -45,7 +52,13 @@ function createDeferred<T>() {
  */
 function createReleaseFeedResponse(
   repositories: RepositoryNode[],
+  options: ReleaseFeedResponseOptions = {},
 ): ReleaseFeedResponse {
+  const pageInfo = {
+    endCursor: options.endCursor ?? null,
+    hasNextPage: options.hasNextPage ?? false,
+  }
+
   return {
     viewer: {
       starredRepositories: {
@@ -66,11 +79,8 @@ function createReleaseFeedResponse(
           },
           url: `https://github.com/${repository.nameWithOwner}`,
         })),
-        pageInfo: {
-          endCursor: null,
-          hasNextPage: false,
-        },
-        totalCount: repositories.length,
+        pageInfo,
+        totalCount: options.totalCount ?? repositories.length,
       },
     },
   }
@@ -95,6 +105,35 @@ function createReleaseNode(release: Partial<ReleaseNode>): ReleaseNode {
     tagName: 'v0.0.0',
     url: 'https://github.com/example/repo/releases/tag/v0.0.0',
     ...release,
+  }
+}
+
+/**
+ * Detects Release Feed GraphQL requests so tests can override the shared default mock safely.
+ * @param postData - Raw GraphQL request body from Playwright's route handler.
+ * @returns Parsed operation details when the request is a Release Feed operation, otherwise null.
+ * @example
+ * parseReleaseFeedOperation('{"operationName":"getViewerStarredRepositoryReleases"}')
+ */
+function parseReleaseFeedOperation(postData: string | null) {
+  if (!postData) {
+    return null
+  }
+
+  try {
+    const operation = JSON.parse(postData) as {
+      operationName?: string
+      query?: string
+      variables?: Record<string, unknown>
+    }
+    const isReleaseFeedOperation =
+      operation.operationName === 'getViewerStarredRepositoryReleases' ||
+      operation.query?.includes('query getViewerStarredRepositoryReleases') ===
+        true
+
+    return isReleaseFeedOperation ? operation : null
+  } catch {
+    return null
   }
 }
 
@@ -284,5 +323,267 @@ test.describe('Release Feed route', () => {
         'Star repositories on GitHub to start building your release feed.',
       ),
     ).toBeVisible()
+  })
+
+  test('shows an initial network error and retries the failed release query', async ({
+    page,
+    appPage,
+  }) => {
+    // Arrange
+    let releaseFeedRequestCount = 0
+    await page.route(GITHUB_GRAPHQL_API_URL, async (route) => {
+      const operation = parseReleaseFeedOperation(route.request().postData())
+
+      if (!operation) {
+        await route.fallback()
+        return
+      }
+
+      releaseFeedRequestCount += 1
+
+      if (releaseFeedRequestCount === 1) {
+        await route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            errors: [{ message: 'Network request failed' }],
+          }),
+        })
+        return
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: createReleaseFeedResponse([
+            {
+              id: 'repo-retry',
+              nameWithOwner: 'example/retry',
+              ownerLogin: 'example',
+              releases: [
+                createReleaseNode({
+                  id: 'release-retry',
+                  name: 'Retry Works',
+                  tagName: 'v1.0.0',
+                  url: 'https://github.com/example/retry/releases/tag/v1.0.0',
+                }),
+              ],
+            },
+          ]),
+        }),
+      })
+    })
+
+    // Act
+    await appPage.gotoReleases()
+
+    // Assert
+    await expect(
+      page.getByText('Release Feed could not load releases. Please try again.'),
+    ).toBeVisible()
+
+    // Act
+    await page.getByRole('button', { name: 'Retry' }).click()
+
+    // Assert
+    await expect(page.getByText('Retry Works')).toBeVisible()
+    expect(releaseFeedRequestCount).toBe(2)
+  })
+
+  test('loads the next starred repository page when the bottom sentinel enters view', async ({
+    page,
+    appPage,
+    graphqlMocker,
+  }) => {
+    // Arrange
+    const deferredNextPage = createDeferred<ReleaseFeedResponse>()
+    graphqlMocker.mockOperation(
+      'getViewerStarredRepositoryReleases',
+      (operation) => {
+        if (operation.variables?.starredAfter === 'starred-cursor-1') {
+          return deferredNextPage.promise
+        }
+
+        return createReleaseFeedResponse(
+          [
+            {
+              id: 'repo-first-page',
+              nameWithOwner: 'example/first-page',
+              ownerLogin: 'example',
+              releases: [
+                createReleaseNode({
+                  id: 'release-first-page',
+                  name: 'First Page Release',
+                  publishedAt: '2026-06-22T00:00:00Z',
+                  tagName: 'v1.0.0',
+                  url: 'https://github.com/example/first-page/releases/tag/v1.0.0',
+                }),
+              ],
+            },
+          ],
+          {
+            endCursor: 'starred-cursor-1',
+            hasNextPage: true,
+            totalCount: 2,
+          },
+        )
+      },
+    )
+
+    // Act
+    await appPage.gotoReleases()
+    await expect(page.getByText('First Page Release')).toBeVisible()
+    await page
+      .getByTestId('release-feed-pagination-sentinel')
+      .scrollIntoViewIfNeeded()
+
+    // Assert
+    await expect(
+      page.getByRole('status', { name: 'Loading more releases' }),
+    ).toBeVisible()
+
+    // Act
+    deferredNextPage.resolve(
+      createReleaseFeedResponse(
+        [
+          {
+            id: 'repo-second-page',
+            nameWithOwner: 'example/second-page',
+            ownerLogin: 'example',
+            releases: [
+              createReleaseNode({
+                id: 'release-second-page',
+                name: 'Second Page Release',
+                publishedAt: '2026-06-23T00:00:00Z',
+                tagName: 'v2.0.0',
+                url: 'https://github.com/example/second-page/releases/tag/v2.0.0',
+              }),
+            ],
+          },
+        ],
+        { totalCount: 2 },
+      ),
+    )
+
+    // Assert
+    const releaseCards = page.getByTestId('release-feed-card')
+    await expect(releaseCards).toHaveCount(2)
+    await expect(releaseCards.nth(0)).toContainText('Second Page Release')
+    await expect(releaseCards.nth(1)).toContainText('First Page Release')
+  })
+
+  test('keeps loaded releases visible when pagination fails and retry loads the next page', async ({
+    page,
+    appPage,
+  }) => {
+    // Arrange
+    let releaseFeedRequestCount = 0
+    await page.route(GITHUB_GRAPHQL_API_URL, async (route) => {
+      const operation = parseReleaseFeedOperation(route.request().postData())
+
+      if (!operation) {
+        await route.fallback()
+        return
+      }
+
+      releaseFeedRequestCount += 1
+
+      if (!operation.variables?.starredAfter) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: createReleaseFeedResponse(
+              [
+                {
+                  id: 'repo-cached',
+                  nameWithOwner: 'example/cached',
+                  ownerLogin: 'example',
+                  releases: [
+                    createReleaseNode({
+                      id: 'release-cached',
+                      name: 'Cached Release',
+                      tagName: 'v1.0.0',
+                      url: 'https://github.com/example/cached/releases/tag/v1.0.0',
+                    }),
+                  ],
+                },
+              ],
+              {
+                endCursor: 'starred-cursor-1',
+                hasNextPage: true,
+                totalCount: 2,
+              },
+            ),
+          }),
+        })
+        return
+      }
+
+      if (releaseFeedRequestCount === 2) {
+        await route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            errors: [{ message: 'Network request failed' }],
+          }),
+        })
+        return
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: createReleaseFeedResponse(
+            [
+              {
+                id: 'repo-recovered',
+                nameWithOwner: 'example/recovered',
+                ownerLogin: 'example',
+                releases: [
+                  createReleaseNode({
+                    id: 'release-recovered',
+                    name: 'Recovered Release',
+                    tagName: 'v2.0.0',
+                    url: 'https://github.com/example/recovered/releases/tag/v2.0.0',
+                  }),
+                ],
+              },
+            ],
+            { totalCount: 2 },
+          ),
+        }),
+      })
+    })
+
+    // Act
+    await appPage.gotoReleases()
+    await expect(page.getByText('Cached Release')).toBeVisible()
+    const paginationSentinel = page.getByTestId(
+      'release-feed-pagination-sentinel',
+    )
+    const shouldScrollSentinel = await paginationSentinel
+      .waitFor({ state: 'visible', timeout: 1000 })
+      .then(() => true)
+      .catch(() => false)
+
+    if (shouldScrollSentinel) {
+      await paginationSentinel.scrollIntoViewIfNeeded()
+    }
+
+    // Assert
+    await expect(
+      page.getByText('Release Feed could not load releases. Please try again.'),
+    ).toBeVisible()
+    await expect(page.getByText('Cached Release')).toBeVisible()
+
+    // Act
+    await page.getByRole('button', { name: 'Retry' }).click()
+
+    // Assert
+    await expect(page.getByText('Recovered Release')).toBeVisible()
+    expect(releaseFeedRequestCount).toBe(3)
   })
 })

--- a/tests/suites/09-release-feed.spec.ts
+++ b/tests/suites/09-release-feed.spec.ts
@@ -580,7 +580,7 @@ test.describe('Release Feed route', () => {
     await expect(page.getByText('Cached Release')).toBeVisible()
 
     // Act
-    await page.getByRole('button', { name: 'Retry' }).click()
+    await page.getByRole('button', { name: 'Retry next page' }).click()
 
     // Assert
     await expect(page.getByText('Recovered Release')).toBeVisible()


### PR DESCRIPTION
## Summary
- Add infinite-scroll pagination for Release Feed starred repository pages.
- Add bottom loading, pagination failure, retry, and partial-error states while keeping loaded releases visible.
- Preserve and explicitly cover both empty states: no starred repositories and starred repositories with no releases.
- Use distinct retry actions for initial failure, partial refresh failure, and next-page failure so the UI and accessible names stay unambiguous.
- Extend unit and Playwright coverage for initial retry, next-page loading, pagination failure, empty states, and merged page ordering.

Closes #1270

## Acceptance Coverage
- Initial loading: `ReleaseFeedLoading` plus Playwright pending-query coverage.
- Bottom loading: `ReleaseFeedPaginationStatus` with `Loading more releases...` status.
- No releases found: existing `No releases were found in your starred repositories yet.` state remains covered.
- No starred repositories: existing `Star repositories on GitHub to start building your release feed.` state remains covered.
- Network retry: initial error uses `Retry`; pagination error uses `Retry next page`; partial data refresh uses `Retry all releases`.
- Partial availability: already loaded release cards remain visible when pagination fails.

## Validation
- pnpm exec vitest run src/routes/ReleasesRoute.test.tsx src/routes/ReleaseFeed/normalizeReleaseFeedItems.test.ts
- pnpm validate
- pnpm exec kill-port 3005 && pnpm exec playwright test tests/suites/09-release-feed.spec.ts --project=chromium --reporter=list
- pnpm exec kill-port 3005 && pnpm exec playwright test --project=chromium --reporter=list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * リリース一覧を下部までスクロールすると次ページを自動で読み込みます。
  * 読み込み中やページ追加の状態を分かりやすく表示します。
* **Bug Fixes**
  * 初回/追加の取得失敗時に「再試行」できるようになりました。
  * 次ページ取得に失敗しても、表示済みのリリースは維持されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->