### PR TITLE
fix: prevent 1Password prompt on username field

### DIFF
--- a/src/app/Sidebar/UserAutocomplete.test.tsx
+++ b/src/app/Sidebar/UserAutocomplete.test.tsx
@@ -88,6 +88,23 @@ describe('UserAutocomplete', () => {
       expect(screen.getByText('@')).toBeInTheDocument()
     })
 
+    it('renders the GitHub username textbox with the 1Password opt-out attribute', () => {
+      // Arrange
+      mockUseGetViewerFollowingQuery.mockReturnValue({
+        data: mockFollowingData,
+        isLoading: false,
+      })
+
+      // Act
+      renderWithTheme(<UserAutocomplete value="" onChange={mockOnChange} />)
+
+      // Assert
+      expect(screen.getByLabelText('GitHub username')).toHaveAttribute(
+        'data-1p-ignore',
+        'true',
+      )
+    })
+
     it('shows suggestions when input is focused', async () => {
       mockUseGetViewerFollowingQuery.mockReturnValue({
         data: mockFollowingData,

--- a/src/app/Sidebar/UserAutocomplete.tsx
+++ b/src/app/Sidebar/UserAutocomplete.tsx
@@ -168,6 +168,8 @@ const UserAutocomplete: React.FC<UserAutocompleteProps> = memo(
               htmlInput: {
                 ...params.slotProps.htmlInput,
                 'aria-label': 'GitHub username',
+                // Tell 1Password to ignore this username picker so its inline prompt stays hidden.
+                'data-1p-ignore': true,
               },
             }}
           />

--- a/tests/suites/08-subscription-flow.spec.ts
+++ b/tests/suites/08-subscription-flow.spec.ts
@@ -173,6 +173,23 @@ test.describe('Subscription Flow with Following Suggestions', () => {
       // Modal should be visible with title
       await expect(getUsernameDialog(page)).toBeVisible()
     })
+
+    test('should mark the username input so 1Password ignores it', async ({
+      page,
+      appPage,
+    }) => {
+      // Arrange
+      await appPage.goto()
+
+      // Act
+      await page.getByRole('button', { name: 'Add subscription' }).click()
+
+      // Assert
+      await expect(getUsernameCombobox(page)).toHaveAttribute(
+        'data-1p-ignore',
+        'true',
+      )
+    })
   })
 
   test.describe('Following Suggestions', () => {


### PR DESCRIPTION
## Summary
- add data-1p-ignore=true to the native GitHub username input
- cover the opt-out attribute in component and browser regression tests

## Why
- follow the 1Password opt-out recommendation for inputs that should not show its inline prompt: https://www.1password.community/discussions/1password/can-i-blacklist-a-website-from-1password/108122/replies/108126

## Verification
- pnpm validate
- pnpm exec vitest run — 46 passed
- pnpm playwright — 393 passed across Chromium, Firefox, and WebKit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * GitHubユーザー名入力欄で、1Passwordのインラインプロンプトを表示しないようにしました。
  * サブスクリプション追加モーダル内の入力欄にも同じ設定を適用しました。
* **テスト**
  * 対象の入力欄で設定が正しく適用されることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->