### PR TITLE
chore: refresh GitHub Actions pins for Node.js 24 runtimes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         name: Install pnpm
         with:
           version: 11.9.0
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           cache: pnpm
           node-version: 22

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,5 +10,5 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - run: gh pr merge "${GITHUB_HEAD_REF}" --merge --auto

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         name: Install pnpm
         with:
           version: 11.9.0
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           cache: pnpm
           node-version: 22

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -24,18 +24,18 @@ jobs:
       PLAYWRIGHT_HTML_OPEN: never
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
           version: 11.9.0
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           cache: pnpm
           node-version: 22
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         name: Install pnpm
         with:
           version: 11.9.0
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           cache: pnpm
           node-version: 22


### PR DESCRIPTION
## Summary

The post-merge Playwright CI run on `7605de9` emitted non-blocking annotations because every pinned action revision still targets the deprecated Node.js 20 Actions runtime and is being forced onto Node.js 24. This refreshes all pins in `.github/workflows/` to the latest stable release of each action. Each new pin's `action.yml` was fetched at the pinned commit and verified to declare `runs.using: node24`.

| Action | Old pin | New pin |
| --- | --- | --- |
| `actions/checkout` | v4.3.1 `34e114876b0b11c390a56381ad16ebd13914f8d5` (node20) | v7.0.1 `3d3c42e5aac5ba805825da76410c181273ba90b1` (node24) |
| `actions/setup-node` | v4.4.0 `49933ea5288caeca8642d1e84afbd3f7d6820020` (node20) | v7.0.0 `820762786026740c76f36085b0efc47a31fe5020` (node24) |
| `actions/upload-artifact` | v4.6.2 `ea165f8d65b6e75b540449e92b4886f43607fa02` (node20) | v7.0.1 `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (node24) |
| `pnpm/action-setup` | v4.3.0 `b906affcce14559ad1aafd4ab0e942779e9f58b1` (node20) | v6.0.9 `0ebf47130e4866e96fce0953f49152a61190b271` (node24) |

`dependabot-auto-merge.yml` used a floating `actions/checkout@v4` tag (also node20); it is now SHA-pinned to the same v7.0.1 commit for consistency with the rest of the workflows.

## Breaking-change review (no input changes needed)

- **checkout v5-v7**: node24 runtime (min runner 2.327.1; GitHub-hosted runners qualify), credentials persisted to a separate file (Playwright job passes `persist-credentials: false`), fork-PR checkout blocked for `pull_request_target`/`workflow_run` (triggers not used here).
- **setup-node v5/v6**: breaking changes only affect automatic package-manager cache detection; these workflows set `cache: pnpm` explicitly, and `package.json` `packageManager` (`pnpm@11.9.0`) matches the workflow-pinned pnpm version.
- **upload-artifact v5-v7**: runtime bump plus an opt-in `archive` input; `name`/`path`/`retention-days` usage is unchanged.
- **pnpm/action-setup v5/v6**: v5 moved to node24, v6 added pnpm v11 support (workflows install pnpm 11.9.0); `version`/`run_install` inputs unchanged.

Workflow-only change; no application code or deploy configuration touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ビルド、Lint、型チェック、E2Eテストの実行環境を更新しました。
  * 各種自動処理の安定性とセキュリティを向上しました。
  * E2Eテスト結果のレポート保存処理を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->